### PR TITLE
[common,thread] Store thread function on the stack

### DIFF
--- a/include/aos/common/config/thread.hpp
+++ b/include/aos/common/config/thread.hpp
@@ -11,9 +11,10 @@
 /**
  * Configures default thread stack size.
  *
+ * Use minimal stack size PTHREAD_STACK_MIN + 2k for storing thread functor.
  */
 #ifndef AOS_CONFIG_DEFAULT_THREAD_STACK_SIZE
-#define AOS_CONFIG_DEFAULT_THREAD_STACK_SIZE 16384
+#define AOS_CONFIG_DEFAULT_THREAD_STACK_SIZE (16384 + 2048)
 #endif
 
 #endif

--- a/include/aos/common/utils.hpp
+++ b/include/aos/common/utils.hpp
@@ -19,7 +19,18 @@ template <typename T, size_t n>
 constexpr size_t ArraySize(T (&)[n])
 {
     return n;
-}
+};
+
+/**
+ * Calculates aligned by machine word size.
+ *
+ * @param size input size.
+ * @return constexpr size_t aligned size.
+ */
+constexpr size_t AlignedSize(size_t size)
+{
+    return (size + sizeof(int) - 1) / sizeof(int) * sizeof(int);
+};
 
 /**
  * Implements struct of pair fields.

--- a/tests/common/src/thread_test.cpp
+++ b/tests/common/src/thread_test.cpp
@@ -51,7 +51,7 @@ TEST(common, Thread)
 
     TestCalculator calc;
 
-    Thread<> incThread([&calc]() {
+    Thread<> incThread([&calc](void*) {
         for (auto i = 0; i < cNumIteration; i++) {
             LockGuard lock(calc.GetMutex());
             EXPECT_TRUE(lock.GetError().IsNone());
@@ -61,7 +61,7 @@ TEST(common, Thread)
             usleep(1000);
         }
     });
-    Thread<> distThread([&]() {
+    Thread<> distThread([&](void*) {
         for (auto i = 0; i < cNumIteration; i++) {
             LockGuard lock(calc.GetMutex());
 
@@ -98,7 +98,7 @@ TEST(common, CondVar)
     auto                ready = false;
     auto                processed = false;
 
-    Thread<> worker([&]() {
+    Thread<> worker([&](void*) {
         UniqueLock lock(mutex);
         EXPECT_TRUE(lock.GetError().IsNone());
 


### PR DESCRIPTION
The thread function was stored as static variable inside Thread constructor. But it requires guards for thread-safe initialization of static instances. These guards are part of C++ stdlib in gcc. Disabling them with -fno-threadsafe-statics compiler options may lead to undefined behavior here or other places.

The only place where we can safely store the function is beginning of the thread stack.