### PR TITLE
[sm,launcher] Use image entryPoint field as kernel path parameter

### DIFF
--- a/include/aos/common/ocispec.hpp
+++ b/include/aos/common/ocispec.hpp
@@ -29,7 +29,7 @@ constexpr auto cMaxDigestLen = (128 + 8);
 /**
  * Spec parameter max len.
  */
-constexpr auto cMaxParamLen = 64;
+constexpr auto cMaxParamLen = 256;
 
 /**
  * Spec parameter max count.

--- a/src/sm/launcher/instance.cpp
+++ b/src/sm/launcher/instance.cpp
@@ -152,7 +152,8 @@ Error Instance::CreateRuntimeSpec(const String& path)
 
     // Set default HW config values. Normally they should be taken from service config.
     runtimeSpec->mVM->mHWConfig.mVCPUs = 1;
-    runtimeSpec->mVM->mHWConfig.mMemKB = 4096;
+    // For xen this value should be aligned to 1024Kb
+    runtimeSpec->mVM->mHWConfig.mMemKB = 8192;
 
     runtimeSpec->mVM->mKernel.mPath = FS::JoinPath(serviceFS.mValue, imageSpec.mValue.mConfig.mEntryPoint[0]);
     runtimeSpec->mVM->mKernel.mParameters = imageSpec.mValue.mConfig.mCmd;

--- a/src/sm/launcher/instance.cpp
+++ b/src/sm/launcher/instance.cpp
@@ -146,7 +146,7 @@ Error Instance::CreateRuntimeSpec(const String& path)
     auto vm = MakeUnique<oci::VM>(&sAllocator);
     runtimeSpec->mVM = vm.Get();
 
-    if (imageSpec.mValue.mConfig.mCmd.Size() == 0) {
+    if (imageSpec.mValue.mConfig.mEntryPoint.Size() == 0) {
         return AOS_ERROR_WRAP(ErrorEnum::eInvalidArgument);
     }
 
@@ -154,7 +154,8 @@ Error Instance::CreateRuntimeSpec(const String& path)
     runtimeSpec->mVM->mHWConfig.mVCPUs = 1;
     runtimeSpec->mVM->mHWConfig.mMemKB = 4096;
 
-    runtimeSpec->mVM->mKernel.mPath = FS::JoinPath(serviceFS.mValue, imageSpec.mValue.mConfig.mCmd[0]);
+    runtimeSpec->mVM->mKernel.mPath = FS::JoinPath(serviceFS.mValue, imageSpec.mValue.mConfig.mEntryPoint[0]);
+    runtimeSpec->mVM->mKernel.mParameters = imageSpec.mValue.mConfig.mCmd;
 
     LOG_DBG() << "Unikernel path: " << runtimeSpec->mVM->mKernel.mPath;
 

--- a/tests/sm/launcher/launcher_test.cpp
+++ b/tests/sm/launcher/launcher_test.cpp
@@ -183,7 +183,7 @@ public:
     {
         (void)path;
 
-        imageSpec.mConfig.mCmd.EmplaceBack("unikernel");
+        imageSpec.mConfig.mEntryPoint.EmplaceBack("unikernel");
 
         return ErrorEnum::eNone;
     }


### PR DESCRIPTION
Cloud puts first element of cmd array into entryPoint[0] and remaining items to cmd array. Update creating runtime config accordingly.