### PR TITLE
[iam,certmodules] Fix getting TEE login type from env

### DIFF
--- a/src/iam/certmodules/pkcs11/pkcs11.cpp
+++ b/src/iam/certmodules/pkcs11/pkcs11.cpp
@@ -56,14 +56,12 @@ Error PKCS11Module::Init(const String& certType, const PKCS11ModuleConfig& confi
         return AOS_ERROR_WRAP(ErrorEnum::eInvalidArgument);
     }
 
-    Error err = ErrorEnum::eNone;
-
-    err = os::GetEnv(cEnvLoginType, mTeeLoginType);
-    if (!err.IsNone()) {
+    auto err = os::GetEnv(cEnvLoginType, mTeeLoginType);
+    if (!err.IsNone() && !err.Is(ErrorEnum::eNotFound)) {
         return AOS_ERROR_WRAP(err);
     }
 
-    if (!mConfig.mUserPINPath.IsEmpty() && mTeeLoginType.IsEmpty()) {
+    if (mConfig.mUserPINPath.IsEmpty() && mTeeLoginType.IsEmpty()) {
         return AOS_ERROR_WRAP(ErrorEnum::eInvalidArgument);
     }
 


### PR DESCRIPTION
We should not return err if TEE login type env var doesn't exist.