### PR TITLE
[common,config] Rename pem size to pem len in config consts

### DIFF
--- a/include/aos/common/config.hpp
+++ b/include/aos/common/config.hpp
@@ -220,10 +220,10 @@
 #endif
 
 /**
- * Maximum size of a PEM certificate.
+ * Maximum length of a PEM certificate.
  */
-#ifndef AOS_CONFIG_CRYPTO_CERT_PEM_SIZE
-#define AOS_CONFIG_CRYPTO_CERT_PEM_SIZE 4096
+#ifndef AOS_CONFIG_CRYPTO_CERT_PEM_LEN
+#define AOS_CONFIG_CRYPTO_CERT_PEM_LEN 4096
 #endif
 
 /**
@@ -234,10 +234,10 @@
 #endif
 
 /**
- * Maximum size of CSR in PEM format.
+ * Maximum length of CSR in PEM format.
  */
-#ifndef AOS_CONFIG_CRYPTO_CSR_PEM_SIZE
-#define AOS_CONFIG_CRYPTO_CSR_PEM_SIZE 4096
+#ifndef AOS_CONFIG_CRYPTO_CSR_PEM_LEN
+#define AOS_CONFIG_CRYPTO_CSR_PEM_LEN 4096
 #endif
 
 /**

--- a/include/aos/common/crypto.hpp
+++ b/include/aos/common/crypto.hpp
@@ -64,9 +64,9 @@ constexpr auto cASN1ExtValueSize = AOS_CONFIG_CRYPTO_ASN1_EXTENSION_VALUE_SIZE;
 constexpr auto cCertKeyIdSize = AOS_CONFIG_CRYPTO_CERT_KEY_ID_SIZE;
 
 /**
- * Maximum size of a PEM certificate.
+ * Maximum length of a PEM certificate.
  */
-constexpr auto cCertPEMSize = AOS_CONFIG_CRYPTO_CERT_PEM_SIZE;
+constexpr auto cCertPEMLen = AOS_CONFIG_CRYPTO_CERT_PEM_LEN;
 
 /**
  * Maximum size of a DER certificate.
@@ -74,9 +74,9 @@ constexpr auto cCertPEMSize = AOS_CONFIG_CRYPTO_CERT_PEM_SIZE;
 constexpr auto cCertDERSize = AOS_CONFIG_CRYPTO_CERT_DER_SIZE;
 
 /**
- * Maximum size of CSR in PEM format.
+ * Maximum length of CSR in PEM format.
  */
-constexpr auto cCSRPEMSize = AOS_CONFIG_CRYPTO_CSR_PEM_SIZE;
+constexpr auto cCSRPEMLen = AOS_CONFIG_CRYPTO_CSR_PEM_LEN;
 
 /**
  *  Serial number size(in bytes).

--- a/include/aos/common/cryptoutils.hpp
+++ b/include/aos/common/cryptoutils.hpp
@@ -47,13 +47,13 @@ public:
     RetWithError<SharedPtr<crypto::PrivateKeyItf>> LoadPrivKeyByURL(const String& url);
 
 private:
-    using PEMCertChainBlob = StaticString<crypto::cCertPEMSize * crypto::cCertChainSize>;
+    using PEMCertChainBlob = StaticString<crypto::cCertPEMLen * crypto::cCertChainSize>;
 
     static constexpr auto cCertAllocatorSize
         = AOS_CONFIG_CRYPTOUTILS_CERTIFICATE_CHAINS_COUNT * crypto::cCertChainSize * sizeof(crypto::x509::Certificate)
         + sizeof(PEMCertChainBlob);
     static constexpr auto cKeyAllocatorSize
-        = AOS_CONFIG_CRYPTOUTILS_KEYS_COUNT * pkcs11::cPrivateKeyMaxSize + sizeof(crypto::cCertPEMSize);
+        = AOS_CONFIG_CRYPTOUTILS_KEYS_COUNT * pkcs11::cPrivateKeyMaxSize + sizeof(crypto::cCertPEMLen);
 
     static constexpr auto cDefaultPKCS11Library = AOS_CONFIG_CRYPTOUTILS_DEFAULT_PKCS11_LIB;
 

--- a/include/aos/iam/certmodules/certmodule.hpp
+++ b/include/aos/iam/certmodules/certmodule.hpp
@@ -225,7 +225,7 @@ private:
 
     using ModuleCertificates    = StaticArray<CertInfo, cCertsPerModule>;
     using CertificateChain      = StaticArray<crypto::x509::Certificate, crypto::cCertChainSize>;
-    using SelfSignedCertificate = StaticString<crypto::cCertPEMSize>;
+    using SelfSignedCertificate = StaticString<crypto::cCertPEMLen>;
 
     Error RemoveInvalidCerts(const String& password);
     Error RemoveInvalidKeys(const String& password);

--- a/src/common/cryptoutils.cpp
+++ b/src/common/cryptoutils.cpp
@@ -195,7 +195,7 @@ RetWithError<SharedPtr<crypto::x509::CertificateChain>> CertLoader::LoadCertsFro
 
 RetWithError<SharedPtr<crypto::PrivateKeyItf>> CertLoader::LoadPrivKeyFromFile(const String& fileName)
 {
-    auto buff = MakeUnique<StaticString<crypto::cCertPEMSize>>(&mKeyAllocator);
+    auto buff = MakeUnique<StaticString<crypto::cCertPEMLen>>(&mKeyAllocator);
 
     auto err = FS::ReadFileToString(fileName, *buff);
     if (!err.IsNone()) {

--- a/tests/common/src/crypto_test.cpp
+++ b/tests/common/src/crypto_test.cpp
@@ -114,7 +114,7 @@ static std::pair<aos::Error, std::vector<unsigned char>> GenerateECPrivateKey()
     return {aos::ErrorEnum::eNone, keyBuf};
 }
 
-static int PemToDer(const char* pemData, size_t pemSize, std::vector<unsigned char>& derData)
+static int PemToDer(const char* pemData, size_t pemLen, std::vector<unsigned char>& derData)
 {
     mbedtls_x509_crt cert;
 
@@ -122,7 +122,7 @@ static int PemToDer(const char* pemData, size_t pemSize, std::vector<unsigned ch
 
     std::unique_ptr<mbedtls_x509_crt, decltype(&mbedtls_x509_crt_free)> derDataPtr(&cert, mbedtls_x509_crt_free);
 
-    auto ret = mbedtls_x509_crt_parse(derDataPtr.get(), reinterpret_cast<const uint8_t*>(pemData), pemSize);
+    auto ret = mbedtls_x509_crt_parse(derDataPtr.get(), reinterpret_cast<const uint8_t*>(pemData), pemLen);
     if (ret != 0) {
         return ret;
     }
@@ -423,8 +423,8 @@ TEST(CryptoTest, DERToX509Certs)
 
     aos::crypto::RSAPublicKey rsaPublicKey {mN, mE};
 
-    RSAPrivateKey                                rsaPK {rsaPublicKey, std::move(rsaPKRet.second)};
-    aos::StaticString<aos::crypto::cCertPEMSize> pemCRT;
+    RSAPrivateKey                               rsaPK {rsaPublicKey, std::move(rsaPKRet.second)};
+    aos::StaticString<aos::crypto::cCertPEMLen> pemCRT;
 
     ASSERT_EQ(crypto.CreateCertificate(templ, parent, rsaPK, pemCRT), aos::ErrorEnum::eNone);
 
@@ -496,7 +496,7 @@ TEST(CryptoTest, PEMToX509Certs)
 
     ECDSAPrivateKey ecdsaPK(ecdsaPublicKey, std::move(ecPrivateKey.second));
 
-    aos::StaticString<aos::crypto::cCertPEMSize> pemCRT;
+    aos::StaticString<aos::crypto::cCertPEMLen> pemCRT;
 
     ASSERT_EQ(crypto.CreateCertificate(templ, parent, ecdsaPK, pemCRT), aos::ErrorEnum::eNone);
 
@@ -613,8 +613,8 @@ TEST(CryptoTest, CreateSelfSignedCert)
 
     aos::crypto::RSAPublicKey rsaPublicKey {mN, mE};
 
-    RSAPrivateKey                                rsaPK {rsaPublicKey, std::move(rsaPKRet.second)};
-    aos::StaticString<aos::crypto::cCertPEMSize> pemCRT;
+    RSAPrivateKey                               rsaPK {rsaPublicKey, std::move(rsaPKRet.second)};
+    aos::StaticString<aos::crypto::cCertPEMLen> pemCRT;
 
     ASSERT_EQ(crypto.CreateCertificate(templ, parent, rsaPK, pemCRT), aos::ErrorEnum::eNone);
 


### PR DESCRIPTION
We use size `len` for string const. As now we use PEM as String, corresponding consts should be renamed.