### PR TITLE
[common,pkcs11] Fix getting slot list if slots are changed

### DIFF
--- a/src/common/pkcs11/pkcs11.cpp
+++ b/src/common/pkcs11/pkcs11.cpp
@@ -385,16 +385,22 @@ Error LibraryContext::GetSlotList(bool tokenPresent, Array<SlotID>& slotList) co
         return ErrorEnum::eWrongState;
     }
 
-    slotList.Resize(slotList.MaxSize());
+    CK_ULONG count = 0;
 
-    CK_ULONG count = slotList.MaxSize();
-
-    CK_RV rv = mFunctionList->C_GetSlotList(static_cast<CK_BBOOL>(tokenPresent), slotList.Get(), &count);
+    CK_RV rv = mFunctionList->C_GetSlotList(static_cast<CK_BBOOL>(tokenPresent), nullptr, &count);
     if (rv != CKR_OK) {
         return static_cast<int>(rv);
     }
 
-    slotList.Resize(count);
+    auto err = slotList.Resize(count);
+    if (!err.IsNone()) {
+        return err;
+    }
+
+    rv = mFunctionList->C_GetSlotList(static_cast<CK_BBOOL>(tokenPresent), slotList.Get(), &count);
+    if (rv != CKR_OK) {
+        return static_cast<int>(rv);
+    }
 
     return ErrorEnum::eNone;
 }


### PR DESCRIPTION
According to documentation: changes in slot number or initialization will only be visible and effective if C_GetSlotListis called again with NULL slot list. Add NULL slot list read to have up to date slots information.