### PR TITLE
[common,tools] Implement duration as a class

### DIFF
--- a/include/aos/common/tools/time.hpp
+++ b/include/aos/common/tools/time.hpp
@@ -18,14 +18,268 @@
 namespace aos {
 
 /**
- * Base type for a time duration in nanoseconds. Can also be negative to set a point back in time.
- */
-using Duration = int64_t;
-
-/**
  * Size of a time in string representation.
  */
 const auto cTimeStrLen = AOS_CONFIG_TIME_STR_LEN;
+
+/**
+ * Base type for a time duration in nanoseconds. Can also be negative to set a point back in time.
+ */
+class Duration {
+public:
+    /**
+     * Default constructor.
+     */
+    constexpr Duration() = default;
+
+    // cppcheck-suppress noExplicitConstructor
+    /**
+     * Constructs object instance.
+     *
+     * @param duration duration in nanoseconds.
+     */
+    constexpr Duration(int64_t duration)
+        : mDuration(duration)
+    {
+    }
+
+    /**
+     * Returns duration in nanoseconds.
+     *
+     * @result int64_t.
+     */
+    int64_t Nanoseconds() const { return mDuration; }
+
+    /**
+     * Returns duration in microseconds.
+     *
+     * @result int64_t.
+     */
+    int64_t Microseconds() const { return Nanoseconds() / 1000; }
+
+    /**
+     * Returns duration in milliseconds.
+     *
+     * @result int64_t.
+     */
+    int64_t Milliseconds() const { return Microseconds() / 1000; }
+
+    /**
+     * Returns duration in seconds.
+     *
+     * @result float.
+     */
+    float Seconds() const { return static_cast<float>(Nanoseconds()) / 1000000000.f; }
+
+    /**
+     * Returns duration in minutes.
+     *
+     * @result float.
+     */
+    float Minutes() const { return Seconds() / 60.f; }
+
+    /**
+     * Returns duration in hours.
+     *
+     * @result float.
+     */
+    float Hours() const { return Minutes() / 60.f; }
+
+    /**
+     * Adds duration to the current object.
+     *
+     * @param duration duration.
+     * @result Duration&.
+     */
+    constexpr Duration& operator+=(const Duration& duration)
+    {
+        mDuration += duration.mDuration;
+
+        return *this;
+    }
+
+    /**
+     * Subtracts duration from the current object.
+     *
+     * @param duration duration.
+     * @result Duration&.
+     */
+    constexpr Duration& operator-=(const Duration& duration)
+    {
+        mDuration -= duration.mDuration;
+
+        return *this;
+    }
+
+    /**
+     * Multiplies duration.
+     *
+     * @param multiplier multiplier.
+     * @result Duration&.
+     */
+    constexpr Duration& operator*=(int64_t multiplier)
+    {
+        mDuration *= multiplier;
+
+        return *this;
+    }
+
+    /**
+     * Multiplies duration.
+     *
+     * @param multiplier multiplier.
+     * @param duration duration.
+     * @result Duration.
+     */
+    friend constexpr Duration operator*(int64_t multiplier, Duration duration) { return duration * multiplier; }
+
+    /**
+     * Divides duration.
+     *
+     * @param divider divider.
+     * @result Duration&.
+     */
+    constexpr Duration& operator/=(int64_t divider)
+    {
+        assert(divider != 0);
+
+        mDuration /= divider;
+
+        return *this;
+    }
+
+    /**
+     * Divides duration.
+     *
+     * @param divider divider.
+     * @param duration duration.
+     * @result Duration.
+     */
+    friend constexpr Duration operator/(int64_t divider, Duration duration)
+    {
+        assert(divider != 0);
+
+        return duration / divider;
+    }
+
+    /**
+     * Changes sign of the duration.
+     *
+     * @result Duration.
+     */
+    constexpr Duration operator-() const { return -mDuration; }
+
+    /**
+     * Adds duration and returns result as a new object.
+     *
+     * @param duration duration.
+     * @result Duration.
+     */
+    constexpr Duration operator+(const Duration& duration) const { return mDuration + duration.mDuration; }
+
+    /**
+     * Subtracts duration and returns result as a new object.
+     *
+     * @param duration duration.
+     * @result Duration.
+     */
+    constexpr Duration operator-(const Duration& duration) const { return mDuration - duration.mDuration; }
+
+    /**
+     * Multiplies duration and returns result as a new object.
+     *
+     * @param multiplier multiplier.
+     * @result Duration.
+     */
+    constexpr Duration operator*(int64_t multiplier) const { return mDuration * multiplier; }
+
+    /**
+     * Divides duration and returns result as a new object.
+     *
+     * @param divider divider.
+     * @result Duration.
+     */
+    constexpr Duration operator/(const int64_t divider) const
+    {
+        assert(divider != 0);
+
+        return mDuration / divider;
+    }
+
+    /**
+     * Returns true if duration is not zero.
+     *
+     * @return bool.
+     */
+    explicit operator bool() const { return mDuration != 0; }
+
+    /**
+     * Compares two durations.
+     *
+     * @param obj duration to compare with.
+     * @result bool.
+     */
+    bool operator==(const Duration& obj) const { return mDuration == obj.mDuration; }
+
+    /**
+     * Compares two durations.
+     *
+     * @param obj duration to compare with.
+     * @result bool.
+     */
+    bool operator!=(const Duration& obj) const { return !operator==(obj); }
+
+    /**
+     * Compares two durations.
+     *
+     * @param obj duration to compare with.
+     * @result bool.
+     */
+    bool operator<(const Duration& obj) const { return mDuration < obj.mDuration; }
+
+    /**
+     * Compares two durations.
+     *
+     * @param obj duration to compare with.
+     * @result bool.
+     */
+    bool operator<=(const Duration& obj) const { return mDuration <= obj.mDuration; }
+
+    /**
+     * Compares two durations.
+     *
+     * @param obj duration to compare with.
+     * @result bool.
+     */
+    bool operator>(const Duration& obj) const { return mDuration > obj.mDuration; }
+
+    /**
+     * Compares two durations.
+     *
+     * @param obj duration to compare with.
+     * @result bool.
+     */
+    bool operator>=(const Duration& obj) const { return mDuration >= obj.mDuration; }
+
+    /**
+     * Returns ISO 8601 duration string representation.
+     *
+     * @return StaticString<cTimeStrLen>
+     */
+    StaticString<cTimeStrLen> ToISO8601String() const;
+
+    /**
+     * Logs duration.
+     *
+     * @param log log object.
+     * @param duration duration.
+     * @return Log&.
+     */
+    friend Log& operator<<(Log& log, const Duration& duration) { return log << duration.ToISO8601String(); }
+
+private:
+    int64_t mDuration = 0;
+};
 
 /**
  * An object specifying a time instant.
@@ -41,7 +295,10 @@ public:
     static constexpr Duration cSeconds      = 1000 * cMilliseconds;
     static constexpr Duration cMinutes      = 60 * cSeconds;
     static constexpr Duration cHours        = 60 * cMinutes;
+    static constexpr Duration cDay          = 24 * cHours;
+    static constexpr Duration cWeek         = 7 * cDay;
     static constexpr Duration cYear         = 31556925974740 * cMicroseconds;
+    static constexpr Duration cMonth        = cYear / 12;
 
     /**
      * Constructs object instance
@@ -101,14 +358,14 @@ public:
     {
         auto time = mTime;
 
-        int64_t nsec = time.tv_nsec + duration;
+        int64_t nsec = time.tv_nsec + duration.Nanoseconds();
 
-        time.tv_sec += nsec / cSeconds;
-        time.tv_nsec = nsec % cSeconds;
+        time.tv_sec += nsec / cSeconds.Nanoseconds();
+        time.tv_nsec = nsec % cSeconds.Nanoseconds();
 
         // sign of the remainder implementation defined => correct if negative
         if (time.tv_nsec < 0) {
-            time.tv_nsec += cSeconds;
+            time.tv_nsec += cSeconds.Nanoseconds();
             time.tv_sec--;
         }
 
@@ -136,7 +393,7 @@ public:
      */
     uint64_t UnixNano() const
     {
-        uint64_t nsec = mTime.tv_nsec + mTime.tv_sec * cSeconds;
+        uint64_t nsec = mTime.tv_nsec + mTime.tv_sec * cSeconds.Nanoseconds();
 
         return nsec;
     }

--- a/include/aos/common/tools/timer.hpp
+++ b/include/aos/common/tools/timer.hpp
@@ -71,12 +71,12 @@ public:
         sev.sigev_value.sival_ptr = this;
         sev.sigev_notify_function = TimerFunction;
 
-        its.it_value.tv_sec  = interval / Time::cSeconds;
-        its.it_value.tv_nsec = interval % Time::cSeconds;
+        its.it_value.tv_sec  = interval.Nanoseconds() / Time::cSeconds.Nanoseconds();
+        its.it_value.tv_nsec = interval.Nanoseconds() % Time::cSeconds.Nanoseconds();
 
         if (!mOneShot) {
-            its.it_interval.tv_sec  = interval / Time::cSeconds;
-            its.it_interval.tv_nsec = interval % Time::cSeconds;
+            its.it_interval.tv_sec  = interval.Nanoseconds() / Time::cSeconds.Nanoseconds();
+            its.it_interval.tv_nsec = interval.Nanoseconds() % Time::cSeconds.Nanoseconds();
         }
 
         auto ret = timer_create(CLOCK_MONOTONIC, &sev, &mTimerID);

--- a/include/aos/sm/launcher/config.hpp
+++ b/include/aos/sm/launcher/config.hpp
@@ -26,7 +26,7 @@ struct Config {
     StaticString<cFilePathLen>                                mStateDir;
     StaticArray<StaticString<cFilePathLen>, cMaxNumHostBinds> mHostBinds;
     StaticArray<Host, cMaxNumHosts>                           mHosts;
-    Duration                                                  mRemoveOutdatedPeriod = 1 * Time::cHours;
+    Duration                                                  mRemoveOutdatedPeriod = Time::cHours;
 };
 
 } // namespace aos::sm::launcher

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -96,6 +96,7 @@ add_library(
     pkcs11/pkcs11.cpp
     pkcs11/privatekey.cpp
     tools/semver.cpp
+    tools/time.cpp
     tools/uuid.cpp
 )
 

--- a/src/common/monitoring/resourcemonitor.cpp
+++ b/src/common/monitoring/resourcemonitor.cpp
@@ -46,7 +46,9 @@ Error ResourceMonitor::Init(const Config& config, iam::nodeinfoprovider::NodeInf
 
     assert(mConfig.mPollPeriod > 0);
 
-    if (auto err = mAverage.Init(nodeInfo->mPartitions, mConfig.mAverageWindow / mConfig.mPollPeriod); !err.IsNone()) {
+    if (auto err = mAverage.Init(
+            nodeInfo->mPartitions, mConfig.mAverageWindow.Nanoseconds() / mConfig.mPollPeriod.Nanoseconds());
+        !err.IsNone()) {
         return AOS_ERROR_WRAP(err);
     }
 

--- a/src/common/tools/time.cpp
+++ b/src/common/tools/time.cpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2025 EPAM Systems, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "aos/common/tools/time.hpp"
+
+namespace aos {
+
+/***********************************************************************************************************************
+ * Public
+ **********************************************************************************************************************/
+
+StaticString<cTimeStrLen> Duration::ToISO8601String() const
+{
+    if (mDuration == 0) {
+        return "PT0S";
+    }
+
+    StaticString<cTimeStrLen> result = (mDuration < 0) ? "-P" : "P";
+
+    auto total = abs(mDuration);
+    char buffer[16];
+
+    if (auto years = total / Time::cYear.Nanoseconds(); years > 0) {
+        snprintf(buffer, sizeof(buffer), "%ldY", years);
+
+        result.Append(buffer);
+
+        total %= Time::cYear.Nanoseconds();
+    }
+
+    if (auto months = total / Time::cMonth.Nanoseconds(); months > 0) {
+        snprintf(buffer, sizeof(buffer), "%ldM", months);
+
+        result.Append(buffer);
+        total %= Time::cMonth.Nanoseconds();
+    }
+
+    if (auto weeks = total / Time::cWeek.Nanoseconds(); weeks > 0) {
+        snprintf(buffer, sizeof(buffer), "%ldW", weeks);
+
+        result.Append(buffer);
+
+        total %= Time::cWeek.Nanoseconds();
+    }
+
+    if (auto days = total / Time::cDay.Nanoseconds(); days > 0) {
+        snprintf(buffer, sizeof(buffer), "%ldD", days);
+
+        result.Append(buffer);
+
+        total %= Time::cDay.Nanoseconds();
+    }
+
+    const auto hours = total / Time::cHours.Nanoseconds();
+    total %= Time::cHours.Nanoseconds();
+
+    const auto minutes = total / Time::cMinutes.Nanoseconds();
+    total %= Time::cMinutes.Nanoseconds();
+
+    auto seconds = total / Time::cSeconds.Nanoseconds();
+    total %= Time::cSeconds.Nanoseconds();
+
+    if (hours || minutes || seconds || total) {
+        result.Append("T");
+
+        if (hours) {
+            snprintf(buffer, sizeof(buffer), "%ldH", hours);
+            result.Append(buffer);
+        }
+
+        if (minutes) {
+            snprintf(buffer, sizeof(buffer), "%ldM", minutes);
+            result.Append(buffer);
+        }
+
+        if (total == 0 && seconds > 0) {
+            snprintf(buffer, sizeof(buffer), "%ldS", seconds);
+            result.Append(buffer);
+        }
+
+        if (total > 0) {
+            const auto rest = static_cast<double>(total) / Time::cSeconds.Nanoseconds() + static_cast<double>(seconds);
+
+            snprintf(buffer, sizeof(buffer), "%0.9lfS", rest);
+            result.Append(buffer);
+        }
+    }
+
+    return result;
+}
+
+} // namespace aos

--- a/src/sm/launcher/launcher.cpp
+++ b/src/sm/launcher/launcher.cpp
@@ -993,7 +993,7 @@ Error Launcher::GetOutdatedInstances(Array<InstanceData>& instances)
     auto now = Time::Now();
 
     for (const auto& instance : mCurrentInstances) {
-        if (instance.GetOfflineTTL() && now.Add(instance.GetOfflineTTL()) < now) {
+        if (instance.GetOfflineTTL() && now.Add(instance.GetOfflineTTL().Nanoseconds()) < now) {
             if (auto err = instances.EmplaceBack(instance.Info(), instance.InstanceID()); !err.IsNone()) {
                 return AOS_ERROR_WRAP(err);
             }

--- a/tests/common/src/monitoring_test.cpp
+++ b/tests/common/src/monitoring_test.cpp
@@ -415,13 +415,13 @@ TEST_F(MonitoringTest, GetNodeMonitoringData)
         "node1", "type1", "name1", NodeStatusEnum::eProvisioned, "linux", {}, nodePartitions, {}, 10000, 8192};
 
     AlertRules alertRules;
-    alertRules.mCPU.SetValue(AlertRulePercents {10, 20, Time::cMilliseconds});
-    alertRules.mRAM.SetValue(AlertRulePercents {20, 30, Time::cMilliseconds});
-    alertRules.mDownload.SetValue(AlertRulePoints {10, 20, Time::cMilliseconds});
-    alertRules.mUpload.SetValue(AlertRulePoints {10, 20, Time::cMilliseconds});
+    alertRules.mCPU.SetValue(AlertRulePercents {Time::cMilliseconds, 10, 20});
+    alertRules.mRAM.SetValue(AlertRulePercents {Time::cMilliseconds, 20, 30});
+    alertRules.mDownload.SetValue(AlertRulePoints {Time::cMilliseconds, 10, 20});
+    alertRules.mUpload.SetValue(AlertRulePoints {Time::cMilliseconds, 10, 20});
 
     for (const auto& partition : nodePartitionsInfo) {
-        ASSERT_TRUE(alertRules.mPartitions.PushBack(PartitionAlertRule {10, 20, Time::cMilliseconds, partition.mName})
+        ASSERT_TRUE(alertRules.mPartitions.PushBack(PartitionAlertRule {Time::cMilliseconds, 10, 20, partition.mName})
                         .IsNone());
     }
 

--- a/tests/common/src/tools/thread_test.cpp
+++ b/tests/common/src/tools/thread_test.cpp
@@ -154,7 +154,7 @@ TEST(ThreadTest, CondVarTimeout)
                         UniqueLock lock(mutex);
                         EXPECT_TRUE(lock.GetError().IsNone());
 
-                        EXPECT_TRUE(condVar.Wait(lock, 1 * Time::cSeconds).IsNone());
+                        EXPECT_TRUE(condVar.Wait(lock, Time::cSeconds).IsNone());
                     })
                     .IsNone());
     usleep(500000);
@@ -168,7 +168,7 @@ TEST(ThreadTest, CondVarTimeout)
                         UniqueLock lock(mutex);
                         EXPECT_TRUE(lock.GetError().IsNone());
 
-                        EXPECT_EQ(condVar.Wait(lock, 100 * Time::cMilliseconds), aos::ErrorEnum::eTimeout);
+                        EXPECT_EQ(condVar.Wait(lock, Time::cMilliseconds * 100), aos::ErrorEnum::eTimeout);
                     })
                     .IsNone());
 
@@ -181,7 +181,7 @@ TEST(ThreadTest, CondVarTimeout)
                         UniqueLock lock(mutex);
                         EXPECT_TRUE(lock.GetError().IsNone());
 
-                        EXPECT_TRUE(condVar.Wait(lock, 1 * Time::cSeconds, [&] { return ready; }).IsNone());
+                        EXPECT_TRUE(condVar.Wait(lock, Time::cSeconds, [&] { return ready; }).IsNone());
                         ready = false;
                     })
                     .IsNone());
@@ -202,7 +202,7 @@ TEST(ThreadTest, CondVarTimeout)
                         UniqueLock lock(mutex);
                         EXPECT_TRUE(lock.GetError().IsNone());
 
-                        EXPECT_EQ(condVar.Wait(lock, 100 * Time::cMilliseconds, [&] { return ready; }),
+                        EXPECT_EQ(condVar.Wait(lock, Time::cMilliseconds * 100, [&] { return ready; }),
                             aos::ErrorEnum::eTimeout);
                     })
                     .IsNone());

--- a/tests/common/src/tools/time_test.cpp
+++ b/tests/common/src/tools/time_test.cpp
@@ -18,6 +18,59 @@ private:
     void SetUp() override { test::InitLog(); }
 };
 
+TEST_F(TimeTest, DurationToISO8601String)
+{
+    struct TestCase {
+        Duration    duration;
+        const char* expected;
+    } testCases[] = {
+        {Time::cDay * -6, "-P6D"},
+        {-6 * Time::cDay, "-P6D"},
+        {Time::cWeek, "P1W"},
+        {Time::cWeek * 2, "P2W"},
+        {Time::cWeek / 7, "P1D"},
+        {7 / Time::cWeek, "P1D"},
+        {Time::cWeek - Time::cDay, "P6D"},
+        {Time::cMonth, "P1M"},
+        {Time::cYear, "P1Y"},
+        {Time::cYear + Time::cMonth + Time::cWeek + Time::cDay + Time::cHours, "P1Y1M1W1DT1H"},
+        {Duration(0), "PT0S"},
+        {Duration(1), "PT0.000000001S"},
+        {Time::cMinutes + Time::cSeconds, "PT1M1S"},
+        {Time::cMinutes + Time::cMicroseconds * 32, "PT1M0.000032000S"},
+    };
+
+    for (const auto& testCase : testCases) {
+        LOG_DBG() << "Duration: " << testCase.duration;
+
+        EXPECT_STREQ(testCase.duration.ToISO8601String().CStr(), testCase.expected);
+    }
+}
+
+TEST_F(TimeTest, DurationParts)
+{
+    constexpr auto    cDays    = 8;
+    constexpr auto    cHours   = cDays * 24 + 1;
+    constexpr auto    cMinutes = cHours * 60 + 1;
+    constexpr auto    cSeconds = cMinutes * 60 + 1;
+    constexpr int64_t cMillis  = cSeconds * 1000 + 1;
+    constexpr int64_t cMicros  = cMillis * 1000 + 1;
+    constexpr int64_t cNanos   = cMicros * 1000 + 1;
+
+    constexpr Duration duration = cNanos;
+
+    // Test duration contains 1 milli, micro and nano second
+    // that makes the seconds, minutes, hours to have fractional part
+    constexpr float epsilon = 0.02;
+
+    EXPECT_NEAR(duration.Hours(), cHours, epsilon);
+    EXPECT_NEAR(duration.Minutes(), cMinutes, epsilon);
+    EXPECT_NEAR(duration.Seconds(), cSeconds, epsilon);
+    EXPECT_EQ(duration.Milliseconds(), cMillis);
+    EXPECT_EQ(duration.Microseconds(), cMicros);
+    EXPECT_EQ(duration.Nanoseconds(), cNanos);
+}
+
 TEST_F(TimeTest, Add4Years)
 {
     Time now             = Time::Now();
@@ -27,8 +80,8 @@ TEST_F(TimeTest, Add4Years)
     LOG_INF() << "Time now: " << now;
     LOG_INF() << "Four years later: " << fourYearsLater;
 
-    EXPECT_EQ(now.UnixNano() + Years(4), fourYearsLater.UnixNano());
-    EXPECT_EQ(now.UnixNano() + Years(-4), fourYearsBefore.UnixNano());
+    EXPECT_EQ(now.UnixNano() + Years(4).Nanoseconds(), fourYearsLater.UnixNano());
+    EXPECT_EQ(now.UnixNano() + Years(-4).Nanoseconds(), fourYearsBefore.UnixNano());
 }
 
 TEST_F(TimeTest, Compare)

--- a/tests/common/src/tools/timer_test.cpp
+++ b/tests/common/src/tools/timer_test.cpp
@@ -17,7 +17,7 @@ TEST(TimerTest, CreateAndStop)
     auto       interrupted = 0;
     aos::Timer timer {};
 
-    EXPECT_TRUE(timer.Create(900 * Time::cMilliseconds, [&interrupted](void*) { interrupted = 1; }).IsNone());
+    EXPECT_TRUE(timer.Create(Time::cMilliseconds * 900, [&interrupted](void*) { interrupted = 1; }).IsNone());
 
     sleep(1);
 
@@ -31,7 +31,7 @@ TEST(CommonTest, RaisedOnlyOnce)
     auto       interrupted = 0;
     aos::Timer timer {};
 
-    EXPECT_TRUE(timer.Create(500 * Time::cMilliseconds, [&interrupted](void*) { interrupted++; }).IsNone());
+    EXPECT_TRUE(timer.Create(Time::cMilliseconds * 500, [&interrupted](void*) { interrupted++; }).IsNone());
 
     sleep(2);
 
@@ -45,7 +45,7 @@ TEST(CommonTest, CreateResetStop)
     auto       interrupted = 0;
     aos::Timer timer {};
 
-    EXPECT_TRUE(timer.Create(2000 * Time::cMilliseconds, [&interrupted](void*) { interrupted = 1; }).IsNone());
+    EXPECT_TRUE(timer.Create(Time::cMilliseconds * 2000, [&interrupted](void*) { interrupted = 1; }).IsNone());
 
     sleep(1);
 
@@ -67,7 +67,7 @@ TEST(common, TimerRepeatInterval)
 
     EXPECT_TRUE(timer
                     .Create(
-                        1000 * Time::cMilliseconds, [&interrupted](void*) { interrupted++; }, false)
+                        Time::cMilliseconds * 1000, [&interrupted](void*) { interrupted++; }, false)
                     .IsNone());
 
     sleep(3);

--- a/tests/sm/layermanager/layermanager_test.cpp
+++ b/tests/sm/layermanager/layermanager_test.cpp
@@ -202,7 +202,7 @@ TEST_F(LayerManagerTest, ExpiredLayersAreClearedOnInit)
     auto config = CreateConfig();
     config.mTTL = Time::cSeconds;
 
-    const auto expiredTTL = Time::Now().Add(-config.mTTL * 2);
+    const auto expiredTTL = Time::Now().Add(-config.mTTL.Nanoseconds() * 2);
 
     auto cachedAndExpiredLayer  = CreateLayerData("layer1", 1024, LayerStateEnum::eCached, expiredTTL);
     cachedAndExpiredLayer.mPath = CreateExtractedLayerPath("layer1");
@@ -232,12 +232,12 @@ TEST_F(LayerManagerTest, ExpiredLayersAreClearedOnInit)
 TEST_F(LayerManagerTest, ValidateOutdateLayersByTimer)
 {
     auto config                  = CreateConfig();
-    config.mTTL                  = Time::cSeconds / 2;
+    config.mTTL                  = Time::cSeconds.Nanoseconds() / 2;
     config.mRemoveOutdatedPeriod = Time::cSeconds;
 
     InitTest(config);
 
-    const auto                   expiredTTL     = Time::Now().Add(-config.mTTL * 2);
+    const auto                   expiredTTL     = Time::Now().Add(-config.mTTL.Nanoseconds() * 2);
     const std::vector<LayerData> expectedLayers = {
         CreateLayerData("layer2", 1024, LayerStateEnum::eCached, Time::Now().Add(config.mTTL * 10)),
         CreateLayerData("layer3", 1024, LayerStateEnum::eActive, expiredTTL),

--- a/tests/sm/servicemanager/servicemanager_test.cpp
+++ b/tests/sm/servicemanager/servicemanager_test.cpp
@@ -132,10 +132,10 @@ TEST_F(ServiceManagerTest, DamagedServicesAreRemovedOnStart)
 
 TEST_F(ServiceManagerTest, RemoveOutdatedServicesByTimer)
 {
-    mConfig.mTTL                  = aos::Time::cSeconds / 2;
+    mConfig.mTTL                  = aos::Time::cSeconds.Nanoseconds() / 2;
     mConfig.mRemoveOutdatedPeriod = aos::Time::cSeconds;
 
-    const auto        expiredTime    = aos::Time::Now().Add(-mConfig.mTTL);
+    const auto        expiredTime    = aos::Time::Now().Add(-mConfig.mTTL.Nanoseconds());
     const ServiceData expiredService = {
         "service1", "provider1", "1.0.0", "/aos/services/service1", "", expiredTime, ServiceStateEnum::eCached, 0, 0};
     const std::vector<ServiceData> expected = {


### PR DESCRIPTION
Duration object log examples:

```
[ RUN      ] TimeTest.DurationToString
debug | default | Duration: -P6D
debug | default | Duration: P1W
debug | default | Duration: P1M
debug | default | Duration: P1Y
debug | default | Duration: P1Y1M1W1DT1H
debug | default | Duration: PT0S
debug | default | Duration: PT0.000000001S
debug | default | Duration: PT1M1S
debug | default | Duration: PT1M0.000032000S
```