### PR TITLE
[common,monitoring] Remove use of ellipsis notation

### DIFF
--- a/src/common/monitoring/alertprocessor.cpp
+++ b/src/common/monitoring/alertprocessor.cpp
@@ -49,7 +49,13 @@ public:
         return result;
     }
 
-    Res Visit(...) const { return {}; }
+    template <typename T>
+    Res Visit(const T&) const
+    {
+        assert(false);
+
+        return {};
+    }
 
 private:
     uint64_t                   mCurrentVal;


### PR DESCRIPTION
Passing arguments via an ellipsis bypasses the type checking performed by the compiler.
Additionally, passing an argument with non-POD
class type leads to undefined behavior.
On yocto build this leads to stack usage ~ 7Kb.