### PR TITLE
[common,monitoring] Normalize node monitoring data on spikes

### DIFF
--- a/include/aos/common/monitoring/resourcemonitor.hpp
+++ b/include/aos/common/monitoring/resourcemonitor.hpp
@@ -129,6 +129,7 @@ private:
 
     Error SetupSystemAlerts(const NodeConfig& nodeConfig);
     Error SetupInstanceAlerts(const String& instanceID, const InstanceMonitorParams& instanceParams);
+    void  NormalizeMonitoringData();
     void  ProcessMonitoring();
     void  ProcessAlerts(const MonitoringData& monitoringData, const Time& time, Array<AlertProcessor>& alertProcessors);
     RetWithError<uint64_t> GetCurrentUsage(const ResourceIdentifier& id, const MonitoringData& monitoringData) const;

--- a/src/common/monitoring/resourcemonitor.cpp
+++ b/src/common/monitoring/resourcemonitor.cpp
@@ -508,14 +508,6 @@ void ResourceMonitor::ProcessMonitoring()
 
         mNodeMonitoringData.mTimestamp = Time::Now();
 
-        if (auto err = mResourceUsageProvider->GetNodeMonitoringData(
-                mNodeMonitoringData.mNodeID, mNodeMonitoringData.mMonitoringData);
-            !err.IsNone()) {
-            LOG_ERR() << "Failed to get node monitoring data: err=" << err;
-        }
-
-        mNodeMonitoringData.mMonitoringData.mCPU = CPUToDMIPs(mNodeMonitoringData.mMonitoringData.mCPU);
-
         mNodeMonitoringData.mServiceInstances.Clear();
 
         for (auto& [instanceID, instanceMonitoringData] : mInstanceMonitoringData) {
@@ -536,6 +528,14 @@ void ResourceMonitor::ProcessMonitoring()
 
             mNodeMonitoringData.mServiceInstances.PushBack(instanceMonitoringData);
         }
+
+        if (auto err = mResourceUsageProvider->GetNodeMonitoringData(
+                mNodeMonitoringData.mNodeID, mNodeMonitoringData.mMonitoringData);
+            !err.IsNone()) {
+            LOG_ERR() << "Failed to get node monitoring data: err=" << err;
+        }
+
+        mNodeMonitoringData.mMonitoringData.mCPU = CPUToDMIPs(mNodeMonitoringData.mMonitoringData.mCPU);
 
         if (auto err = mAverage.Update(mNodeMonitoringData); !err.IsNone()) {
             LOG_ERR() << "Failed to update average monitoring data: err=" << err;


### PR DESCRIPTION
Node monitoring data is calculated prior to instance monitoring data. It leads to node monitoring data being reported
with lower values than the instance monitoring data. This patch normalizes node monitoring data on spikes in case accumulated node monitoring data is less than the accumulated instances monitoring data.