### PR TITLE
[common,tools] Improve calculate size util

### DIFF
--- a/src/common/tools/fs.cpp
+++ b/src/common/tools/fs.cpp
@@ -478,7 +478,8 @@ RetWithError<size_t> CalculateSize(const String& path)
     }
 
     while (!dirIterators->IsEmpty()) {
-        auto& dirIt = dirIterators->Back();
+        bool  stepIntoSubdir = false;
+        auto& dirIt          = dirIterators->Back();
 
         while (dirIt.Next()) {
             const auto fullPath = JoinPath(dirIt.GetRootPath(), dirIt->mPath);
@@ -488,7 +489,9 @@ RetWithError<size_t> CalculateSize(const String& path)
                     return {0, AOS_ERROR_WRAP(err)};
                 }
 
-                continue;
+                stepIntoSubdir = true;
+
+                break;
             }
 
             struct stat st;
@@ -497,6 +500,10 @@ RetWithError<size_t> CalculateSize(const String& path)
             }
 
             size += st.st_size;
+        }
+
+        if (stepIntoSubdir) {
+            continue;
         }
 
         dirIterators->Erase(&dirIt);


### PR DESCRIPTION
This patch enables the calculate size utility to handle directories with a number of subdirectories more than dir iterator static array capacity by implementing a non-recursive depth first search algorithm.