### PR TITLE
[cm] Implement identifier pool module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/*
 .vscode/*
 .*/*\!.github
+CMakeUserPresets.json

--- a/include/aos/common/tools/identifierpool.hpp
+++ b/include/aos/common/tools/identifierpool.hpp
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2025 EPAM Systems, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef AOS_IDENTIFIER_POOL_HPP_
+#define AOS_IDENTIFIER_POOL_HPP_
+
+#include "aos/common/tools/noncopyable.hpp"
+#include "aos/common/tools/thread.hpp"
+#include "aos/common/types.hpp"
+
+namespace aos {
+
+/**
+ * Identifier range pool.
+ * @tparam cStartRange pool's range start.
+ * @tparam cRangeEnd pool's range end.
+ * @tparam cMaxNumLockedIDs maximum number of locked identifiers.
+ */
+template <size_t cStartRange, size_t cRangeEnd, size_t cMaxNumLockedIDs>
+class IdentifierRangePool : public NonCopyable {
+public:
+    /**
+     * Validator function type.
+     */
+    using Validator = bool (*)(size_t id);
+
+    /**
+     * Initializes identifier pool.
+     *
+     * @param validator identifier validator functor.
+     * @return Error.
+     */
+    Error Init(Validator validator)
+    {
+        mValidator = validator;
+
+        return ErrorEnum::eNone;
+    }
+
+    /**
+     * Acquires free identifier from pool.
+     *
+     * @return RetWithError<size_t>.
+     */
+    RetWithError<size_t> Acquire()
+    {
+        LockGuard lock {mMutex};
+
+        if (!mValidator) {
+            return {{}, AOS_ERROR_WRAP(ErrorEnum::eFailed)};
+        }
+
+        for (size_t id = cStartRange; id < cRangeEnd; id++) {
+            if (mLockedIds.Find(id) != mLockedIds.end()) {
+                continue;
+            }
+
+            if (!mValidator(id)) {
+                continue;
+            }
+
+            if (auto err = mLockedIds.PushBack(id); !err.IsNone()) {
+                return {{}, AOS_ERROR_WRAP(err)};
+            }
+
+            return id;
+        }
+
+        return {{}, ErrorEnum::eNotFound};
+    }
+
+    /**
+     * Tries to acquire identifier from pool.
+     *
+     * @param id desired identifier to acquire.
+     * @return Error.
+     */
+    Error TryAcquire(size_t id)
+    {
+        LockGuard lock {mMutex};
+
+        if (id < cStartRange || id >= cRangeEnd) {
+            return ErrorEnum::eOutOfRange;
+        }
+
+        if (mLockedIds.Find(id) != mLockedIds.end()) {
+            return ErrorEnum::eFailed;
+        }
+
+        return mLockedIds.PushBack(id);
+    }
+
+    /**
+     * Releases identifier in pool.
+     *
+     * @param id identifier to release.
+     * @return Error.
+     */
+    Error Release(size_t id)
+    {
+        LockGuard lock {mMutex};
+
+        auto it = mLockedIds.Find(id);
+        if (it == mLockedIds.end()) {
+            return ErrorEnum::eNotFound;
+        }
+
+        mLockedIds.Erase(it);
+
+        return ErrorEnum::eNone;
+    }
+
+private:
+    Mutex                                 mMutex;
+    StaticArray<size_t, cMaxNumLockedIDs> mLockedIds;
+    Validator                             mValidator {};
+
+    static_assert(cStartRange < cRangeEnd, "invalid identifier pool range");
+};
+
+} // namespace aos
+
+#endif

--- a/tests/common/CMakeLists.txt
+++ b/tests/common/CMakeLists.txt
@@ -26,6 +26,7 @@ set(SOURCES
     src/tools/error_test.cpp
     src/tools/fs_test.cpp
     src/tools/function_test.cpp
+    src/tools/identifierpool_test.cpp
     src/tools/list_test.cpp
     src/tools/log_test.cpp
     src/tools/map_test.cpp

--- a/tests/common/src/tools/identifierpool_test.cpp
+++ b/tests/common/src/tools/identifierpool_test.cpp
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2025 EPAM Systems, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <gtest/gtest.h>
+
+#include <aos/common/tools/identifierpool.hpp>
+#include <aos/test/log.hpp>
+
+using namespace testing;
+
+namespace aos {
+
+namespace {
+
+/***********************************************************************************************************************
+ * Consts
+ **********************************************************************************************************************/
+
+constexpr size_t cIdsRangeBegin   = 5000;
+constexpr size_t cIdsRangeEnd     = 5010;
+constexpr size_t cMaxNumLockedIDs = 5;
+
+/***********************************************************************************************************************
+ * Types
+ **********************************************************************************************************************/
+
+using IDPool = IdentifierRangePool<cIdsRangeBegin, cIdsRangeEnd, cMaxNumLockedIDs>;
+
+/***********************************************************************************************************************
+ * Static
+ **********************************************************************************************************************/
+
+bool AllIdsAreValid(size_t id)
+{
+    (void)id;
+
+    return true;
+}
+
+bool EvenIdsAreValid(size_t id)
+{
+    return id % 2 == 0;
+}
+
+} // namespace
+
+/***********************************************************************************************************************
+ * Suite
+ **********************************************************************************************************************/
+
+class IdentifierPoolTest : public Test {
+protected:
+    void SetUp() override
+    {
+        test::InitLog();
+
+        mIdentifierPool = std::make_unique<IDPool>();
+    }
+
+    std::unique_ptr<IDPool> mIdentifierPool;
+};
+
+/***********************************************************************************************************************
+ * Tests
+ **********************************************************************************************************************/
+
+TEST_F(IdentifierPoolTest, allIdentifiersAreValid)
+{
+    auto err = mIdentifierPool->Init(AllIdsAreValid);
+    ASSERT_TRUE(err.IsNone()) << err.Message();
+
+    size_t id = 0;
+
+    Tie(id, err) = mIdentifierPool->Acquire();
+    ASSERT_EQ(err, ErrorEnum::eNone);
+    ASSERT_EQ(id, 5000);
+
+    err = mIdentifierPool->TryAcquire(5001);
+    ASSERT_EQ(err, ErrorEnum::eNone);
+
+    err = mIdentifierPool->TryAcquire(5001);
+    ASSERT_EQ(err, ErrorEnum::eFailed);
+
+    err = mIdentifierPool->TryAcquire(0);
+    ASSERT_EQ(err, ErrorEnum::eOutOfRange);
+
+    err = mIdentifierPool->TryAcquire(std::numeric_limits<size_t>::max());
+    ASSERT_EQ(err, ErrorEnum::eOutOfRange);
+
+    Tie(id, err) = mIdentifierPool->Acquire();
+    ASSERT_EQ(err, ErrorEnum::eNone);
+    ASSERT_EQ(id, 5002);
+
+    err = mIdentifierPool->Release(5001);
+    ASSERT_EQ(err, ErrorEnum::eNone);
+
+    Tie(id, err) = mIdentifierPool->Acquire();
+    ASSERT_EQ(err, ErrorEnum::eNone);
+    ASSERT_EQ(id, 5001);
+}
+
+TEST_F(IdentifierPoolTest, getFreeIdReturnsErrorIfPoolNotInitialized)
+{
+    auto [id, err] = mIdentifierPool->Acquire();
+    ASSERT_EQ(err, ErrorEnum::eFailed);
+
+    err = mIdentifierPool->TryAcquire(5000);
+    ASSERT_EQ(err, ErrorEnum::eNone);
+
+    Tie(id, err) = mIdentifierPool->Acquire();
+    ASSERT_EQ(err, ErrorEnum::eFailed);
+}
+
+TEST_F(IdentifierPoolTest, onlyEvenIdsAreValid)
+{
+    auto err = mIdentifierPool->Init(EvenIdsAreValid);
+    ASSERT_TRUE(err.IsNone()) << err.Message();
+
+    size_t id = 0;
+
+    Tie(id, err) = mIdentifierPool->Acquire();
+    ASSERT_EQ(err, ErrorEnum::eNone);
+    ASSERT_EQ(id, 5000);
+
+    Tie(id, err) = mIdentifierPool->Acquire();
+    ASSERT_EQ(err, ErrorEnum::eNone);
+    ASSERT_EQ(id, 5002);
+}
+
+TEST_F(IdentifierPoolTest, lockedIdsExceedsLimit)
+{
+    auto err = mIdentifierPool->Init(AllIdsAreValid);
+    ASSERT_TRUE(err.IsNone()) << err.Message();
+
+    for (size_t i = cIdsRangeBegin; i < cIdsRangeBegin + cMaxNumLockedIDs; ++i) {
+        err = mIdentifierPool->TryAcquire(i);
+        ASSERT_EQ(err, ErrorEnum::eNone);
+    }
+
+    size_t id = 0;
+
+    Tie(id, err) = mIdentifierPool->Acquire();
+    ASSERT_EQ(err.Value(), ErrorEnum::eNoMemory);
+}
+
+} // namespace aos


### PR DESCRIPTION
This patch implements cm identifier pool module,
that is used to manage unique identifiers
for various resources in the system, such as UIDs and GIDs.