### PR TITLE
common: tools: add string compare function

### DIFF
--- a/include/aos/common/tools/string.hpp
+++ b/include/aos/common/tools/string.hpp
@@ -24,6 +24,11 @@ namespace aos {
  */
 class String : public Array<char> {
 public:
+    enum class CaseSensitivity {
+        CaseInsensitive,
+        CaseSensitive,
+    };
+
     /**
      * Creates string.
      */
@@ -764,6 +769,23 @@ public:
         }
 
         return {Size(), ErrorEnum::eNotFound};
+    }
+
+    /**
+     * Compares string with another string.
+     *
+     * @param str string to compare with.
+     * @param caseSensitivity comparation case sensitivity.
+     * @return int: 0 - if strings are equal, <0 - if current string is less than str,
+     *              >0 - if current string is greater than str.
+     */
+    int Compare(const String& str, CaseSensitivity caseSensitivity = CaseSensitivity::CaseSensitive) const
+    {
+        if (caseSensitivity == CaseSensitivity::CaseSensitive) {
+            return strcmp(CStr(), str.CStr());
+        }
+
+        return strcasecmp(CStr(), str.CStr());
     }
 };
 

--- a/src/iam/nodeinfoprovider/nodeinfoprovider.cpp
+++ b/src/iam/nodeinfoprovider/nodeinfoprovider.cpp
@@ -7,27 +7,13 @@
 
 #include "aos/iam/nodeinfoprovider.hpp"
 
-static bool CaseInsensitiveEqual(const aos::String& lhs, const aos::String& rhs)
-{
-    if (lhs.Size() != rhs.Size()) {
-        return false;
-    }
-
-    for (size_t i = 0; i < lhs.Size(); ++i) {
-        if (tolower(lhs[i]) != tolower(rhs[i])) {
-            return false;
-        }
-    }
-
-    return true;
-}
-
 namespace aos::iam::nodeinfoprovider {
 
 bool IsMainNode(const NodeInfo& nodeInfo)
 {
-    return nodeInfo.mAttrs.FindIf([](const auto& attr) { return CaseInsensitiveEqual(attr.mName, cAttrMainNode); })
-        != nodeInfo.mAttrs.end();
+    return nodeInfo.mAttrs.FindIf([](const auto& attr) {
+        return !attr.mName.Compare(cAttrMainNode, String::CaseSensitivity::CaseInsensitive);
+    }) != nodeInfo.mAttrs.end();
 }
 
 } // namespace aos::iam::nodeinfoprovider

--- a/src/sm/launcher/instance.cpp
+++ b/src/sm/launcher/instance.cpp
@@ -254,9 +254,7 @@ Error Instance::CreateAosEnvVars(oci::RuntimeSpec& runtimeSpec)
 
 Error Instance::ApplyImageConfig(const oci::ImageSpec& imageSpec, oci::RuntimeSpec& runtimeSpec)
 {
-    StaticString<cOSTypeLen> os = imageSpec.mOS;
-
-    if (os.ToLower() != cLinuxOS) {
+    if (imageSpec.mOS.Compare(cLinuxOS, String::CaseSensitivity::CaseInsensitive) != 0) {
         return AOS_ERROR_WRAP(Error(ErrorEnum::eNotSupported, "unsupported OS in image config"));
     }
 

--- a/tests/common/src/tools/string_test.cpp
+++ b/tests/common/src/tools/string_test.cpp
@@ -412,3 +412,19 @@ TEST(StringTest, Replace)
     EXPECT_TRUE(err.IsNone());
     EXPECT_EQ(str, "Hi Aos! Goodbye Universe!");
 }
+
+TEST(StringTest, Compare)
+{
+    const auto cLhsStr = String("Test string");
+
+    EXPECT_EQ(cLhsStr.Compare("Test string"), 0);
+    EXPECT_LT(cLhsStr.Compare("Test string1"), 0);
+    EXPECT_LT(cLhsStr.Compare("Test strinh"), 0);
+    EXPECT_GT(cLhsStr.Compare("Test strina"), 0);
+    EXPECT_GT(cLhsStr.Compare("Test"), 0);
+
+    EXPECT_EQ(cLhsStr.Compare("Test string", String::CaseSensitivity::CaseInsensitive), 0);
+    EXPECT_EQ(cLhsStr.Compare("test string", String::CaseSensitivity::CaseInsensitive), 0);
+    EXPECT_EQ(cLhsStr.Compare("TEST STRING", String::CaseSensitivity::CaseInsensitive), 0);
+    EXPECT_LT(cLhsStr.Compare("TEST STRING1", String::CaseSensitivity::CaseInsensitive), 0);
+}


### PR DESCRIPTION
This patch introduces a string compare function that allows comparison of two strings, supporting both
case-sensitive and case-insensitive modes.