### PR TITLE
sm: networkmanager: fix remove instance

### DIFF
--- a/include/aos/sm/networkmanager.hpp
+++ b/include/aos/sm/networkmanager.hpp
@@ -758,6 +758,7 @@ private:
     Error CreateNetwork(const NetworkInfo& network);
     Error GenerateVlanIfName(String& vlanIfName);
     Error DeleteInstanceNetworkConfig(const String& instanceID, const String& networkID);
+    Error CleanupInstanceNetworkResources(const String& instanceID, const String& networkID);
 
     StorageItf*                                                                   mStorage {};
     cni::CNIItf*                                                                  mCNI {};


### PR DESCRIPTION
Previously, when deleting a network we iterated over all its instances and called a cleanup function for each. That function also cleared the cache, which removed the instance object from the map we were iterating. This caused undefined behavior in the loop. The cleanup logic has been adjusted to avoid modifying the container while iterating.


Reviewed-by: Mykhailo Lohvynenko <mykhailo_lohvynenko@epam.com>
Reviewed-by: Mykola Kobets <mykola_kobets@epam.com>
Reviewed-by: Oleksandr Grytsov <oleksandr_grytsov@epam.com>