### PR TITLE
common: tools: string: add strings.h include

### DIFF
--- a/include/aos/common/tools/string.hpp
+++ b/include/aos/common/tools/string.hpp
@@ -14,6 +14,7 @@
 #include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <strings.h>
 
 #include "aos/common/tools/array.hpp"
 


### PR DESCRIPTION
This adds missed include for strcasecmp function.