### PR TITLE
[core-lib] core: iam: fixes needed by core_cpp iam

### DIFF
--- a/src/core/common/iamclient/itf/identprovider.hpp
+++ b/src/core/common/iamclient/itf/identprovider.hpp
@@ -22,7 +22,7 @@ public:
     virtual ~SubjectsListenerItf() = default;
 
     /**
-     * Subjects listener interface.
+     * Notifies about subjects change.
      *
      * @param subjects subject changed messages.
      * @returns Error.

--- a/src/core/common/monitoring/resourcemonitor.cpp
+++ b/src/core/common/monitoring/resourcemonitor.cpp
@@ -29,7 +29,7 @@ Error ResourceMonitor::Init(const Config& config, const iam::nodeinfoprovider::N
     mAlertSender           = &alertSender;
     mCloudConnection       = &cloudConnection;
 
-    auto nodeInfo = MakeUnique<NodeInfoObsolete>(&mAllocator);
+    auto nodeInfo = MakeUnique<NodeInfo>(&mAllocator);
 
     if (auto err = nodeInfoProvider.GetNodeInfo(*nodeInfo); !err.IsNone()) {
         return AOS_ERROR_WRAP(err);
@@ -236,7 +236,7 @@ Error ResourceMonitor::GetAverageMonitoringData(NodeMonitoringData& monitoringDa
  * Private
  **********************************************************************************************************************/
 
-Error ResourceMonitor::InitPartitions(const NodeInfoObsolete& nodeInfo)
+Error ResourceMonitor::InitPartitions(const NodeInfo& nodeInfo)
 {
     for (const auto& partition : nodeInfo.mPartitions) {
         if (auto err = mPartitionInfos.EmplaceBack(); !err.IsNone()) {

--- a/src/core/common/monitoring/resourcemonitor.hpp
+++ b/src/core/common/monitoring/resourcemonitor.hpp
@@ -118,10 +118,10 @@ public:
 
 private:
     static constexpr auto cAllocatorSize
-        = Max(sizeof(NodeInfoObsolete) + sizeof(sm::resourcemanager::NodeConfig) + sizeof(ResourceIdentifier),
+        = Max(sizeof(NodeInfo) + sizeof(sm::resourcemanager::NodeConfig) + sizeof(ResourceIdentifier),
             sizeof(InstanceMonitoringData) + sizeof(AlertProcessorArray) + sizeof(ResourceIdentifier));
 
-    Error        InitPartitions(const NodeInfoObsolete& nodeInfo);
+    Error        InitPartitions(const NodeInfo& nodeInfo);
     String       GetParameterName(const ResourceIdentifier& id) const;
     AlertVariant CreateSystemQuotaAlertTemplate(const ResourceIdentifier& resourceIdentifier) const;
     AlertVariant CreateInstanceQuotaAlertTemplate(

--- a/src/core/common/monitoring/tests/monitoring.cpp
+++ b/src/core/common/monitoring/tests/monitoring.cpp
@@ -56,17 +56,17 @@ void SetInstancesMonitoringData(
     }
 }
 
-std::unique_ptr<NodeInfoObsolete> CreateNodeInfo(const Array<PartitionInfo>& partitions)
+std::unique_ptr<NodeInfo> CreateNodeInfo(const Array<PartitionInfo>& partitions)
 {
-    auto nodeInfo = std::make_unique<NodeInfoObsolete>();
+    auto nodeInfo = std::make_unique<NodeInfo>();
 
-    nodeInfo->mNodeID   = "node1";
-    nodeInfo->mNodeType = "type1";
-    nodeInfo->mName     = "name1";
-    nodeInfo->mState    = NodeStateObsoleteEnum::eProvisioned;
-    nodeInfo->mOSType   = "linux";
-    nodeInfo->mTotalRAM = 8192;
-    nodeInfo->mMaxDMIPS = 10000;
+    nodeInfo->mNodeID     = "node1";
+    nodeInfo->mNodeType   = "type1";
+    nodeInfo->mTitle      = "name1";
+    nodeInfo->mState      = NodeStateEnum::eOnline;
+    nodeInfo->mOSInfo.mOS = "linux";
+    nodeInfo->mTotalRAM   = 8192;
+    nodeInfo->mMaxDMIPS   = 10000;
 
     for (const auto& partition : partitions) {
         if (auto err = nodeInfo->mPartitions.EmplaceBack(); !err.IsNone()) {
@@ -78,7 +78,6 @@ std::unique_ptr<NodeInfoObsolete> CreateNodeInfo(const Array<PartitionInfo>& par
         nodePartition.mName      = partition.mName;
         nodePartition.mPath      = partition.mPath;
         nodePartition.mTotalSize = partition.mTotalSize;
-        nodePartition.mUsedSize  = 0;
     }
 
     return nodeInfo;

--- a/src/core/common/monitoring/tests/stubs/nodeinfoproviderstub.hpp
+++ b/src/core/common/monitoring/tests/stubs/nodeinfoproviderstub.hpp
@@ -16,19 +16,19 @@ namespace aos::monitoring {
  */
 class NodeInfoProviderStub : public iam::nodeinfoprovider::NodeInfoProviderItf {
 public:
-    NodeInfoProviderStub(const NodeInfoObsolete& nodeInfo)
+    NodeInfoProviderStub(const NodeInfo& nodeInfo)
         : mNodeInfo(nodeInfo)
     {
     }
 
-    Error GetNodeInfo(NodeInfoObsolete& nodeInfo) const override
+    Error GetNodeInfo(NodeInfo& nodeInfo) const override
     {
         nodeInfo = mNodeInfo;
 
         return ErrorEnum::eNone;
     }
 
-    Error SetNodeState(const NodeStateObsolete& state) override
+    Error SetNodeState(const NodeState& state) override
     {
         (void)state;
 
@@ -50,7 +50,7 @@ public:
     }
 
 private:
-    NodeInfoObsolete mNodeInfo {};
+    NodeInfo mNodeInfo {};
 };
 
 } // namespace aos::monitoring

--- a/src/core/common/monitoring/tests/stubs/nodeinfoproviderstub.hpp
+++ b/src/core/common/monitoring/tests/stubs/nodeinfoproviderstub.hpp
@@ -28,9 +28,10 @@ public:
         return ErrorEnum::eNone;
     }
 
-    Error SetNodeState(const NodeState& state) override
+    Error SetNodeState(const NodeState& state, bool provisioned) override
     {
         (void)state;
+        (void)provisioned;
 
         return ErrorEnum::eNone;
     }

--- a/src/core/iam/identhandler/identmodules/fileidentifier/config.hpp
+++ b/src/core/iam/identhandler/identmodules/fileidentifier/config.hpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2025 EPAM Systems, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef AOS_CORE_IAM_IDENTHANDLER_IDENTMODULES_FILEIDENTIFIER_CONFIG_HPP_
+#define AOS_CORE_IAM_IDENTHANDLER_IDENTMODULES_FILEIDENTIFIER_CONFIG_HPP_
+
+#include <core/common/consts.hpp>
+#include <core/common/tools/string.hpp>
+
+namespace aos::iam::identhandler {
+
+/** @addtogroup iam Identification and Access Manager
+ *  @{
+ */
+
+/**
+ * FileIdentifier configuration.
+ */
+struct FileIdentifierConfig {
+    /**
+     * System ID path.
+     */
+    StaticString<cFilePathLen> mSystemIDPath;
+
+    /**
+     * Unit model path.
+     */
+    StaticString<cFilePathLen> mUnitModelPath;
+
+    /**
+     * Subjects path.
+     */
+    StaticString<cFilePathLen> mSubjectsPath;
+};
+
+/** @}*/
+
+} // namespace aos::iam::identhandler
+
+#endif

--- a/src/core/iam/identhandler/identmodules/fileidentifier/fileidentifier.cpp
+++ b/src/core/iam/identhandler/identmodules/fileidentifier/fileidentifier.cpp
@@ -16,7 +16,7 @@ namespace aos::iam::identhandler {
  * Public
  **********************************************************************************************************************/
 
-Error FileIdentifier::Init(const Config& config)
+Error FileIdentifier::Init(const FileIdentifierConfig& config)
 {
     LOG_DBG() << "Initialize file identifier";
 

--- a/src/core/iam/identhandler/identmodules/fileidentifier/fileidentifier.hpp
+++ b/src/core/iam/identhandler/identmodules/fileidentifier/fileidentifier.hpp
@@ -12,31 +12,13 @@
 #include <core/iam/config.hpp>
 #include <core/iam/identhandler/identmodule.hpp>
 
+#include "config.hpp"
+
 namespace aos::iam::identhandler {
 
 /** @addtogroup iam Identification and Access Manager
  *  @{
  */
-
-/**
- * FileIdentifier configuration.
- */
-struct Config {
-    /**
-     * System ID path.
-     */
-    StaticString<cFilePathLen> mSystemIDPath;
-
-    /**
-     * Unit model path.
-     */
-    StaticString<cFilePathLen> mUnitModelPath;
-
-    /**
-     * Subjects path.
-     */
-    StaticString<cFilePathLen> mSubjectsPath;
-};
 
 /**
  * File identifier.
@@ -49,7 +31,7 @@ public:
      * @param config module config.
      * @return Error.
      */
-    Error Init(const Config& config);
+    Error Init(const FileIdentifierConfig& config);
 
     /**
      * Starts file identifier.
@@ -90,7 +72,7 @@ private:
     Error ReadSubjects();
 
     Mutex                                              mMutex;
-    Config                                             mConfig;
+    FileIdentifierConfig                               mConfig;
     SystemInfo                                         mSystemInfo;
     StaticArray<StaticString<cIDLen>, cMaxNumSubjects> mSubjects;
 };

--- a/src/core/iam/identhandler/identmodules/fileidentifier/tests/fileidentifier.cpp
+++ b/src/core/iam/identhandler/identmodules/fileidentifier/tests/fileidentifier.cpp
@@ -66,7 +66,7 @@ protected:
         mConfig.mSubjectsPath  = cSubjectsPath;
     }
 
-    Config mConfig;
+    FileIdentifierConfig mConfig;
 };
 
 /***********************************************************************************************************************
@@ -77,7 +77,7 @@ TEST_F(FileIdentifierTest, InitFailsOnEmptyConfig)
 {
     FileIdentifier identifier;
 
-    const auto err = identifier.Init(Config {});
+    const auto err = identifier.Init(FileIdentifierConfig {});
     ASSERT_FALSE(err.IsNone()) << err.Message();
 }
 
@@ -96,7 +96,7 @@ TEST_F(FileIdentifierTest, InitFailsOnUnitVersionFileError)
             f << fileContents;
         }
 
-        const auto err = identifier.Init(Config {});
+        const auto err = identifier.Init(FileIdentifierConfig {});
         EXPECT_FALSE(err.IsNone()) << tests::utils::ErrorToStr(err);
     }
 }

--- a/src/core/iam/nodeinfoprovider/nodeinfoprovider.cpp
+++ b/src/core/iam/nodeinfoprovider/nodeinfoprovider.cpp
@@ -20,7 +20,7 @@ constexpr auto cMaxNumNodeComponents = static_cast<size_t>(CoreComponentEnum::eN
  * Public
  **********************************************************************************************************************/
 
-bool IsMainNode(const NodeInfoObsolete& nodeInfo)
+bool IsMainNode(const NodeInfo& nodeInfo)
 {
     return nodeInfo.mAttrs.FindIf([](const auto& attr) {
         return !attr.mName.Compare(cAttrMainNode, String::CaseSensitivity::CaseInsensitive);

--- a/src/core/iam/nodeinfoprovider/nodeinfoprovider.hpp
+++ b/src/core/iam/nodeinfoprovider/nodeinfoprovider.hpp
@@ -9,7 +9,7 @@
 #define AOS_CORE_IAM_NODEINFOPROVIDER_NODEINFOPROVIDER_HPP_
 
 #include <core/common/tools/error.hpp>
-#include <core/common/types/obsolete.hpp>
+#include <core/common/types/common.hpp>
 
 namespace aos::iam::nodeinfoprovider {
 
@@ -34,7 +34,7 @@ static constexpr auto cAttrNodeRunners = "NodeRunners";
  * @param nodeInfo node info.
  * @return bool.
  */
-bool IsMainNode(const NodeInfoObsolete& nodeInfo);
+bool IsMainNode(const NodeInfo& nodeInfo);
 
 /**
  * Checks if the node contains specified component.
@@ -57,7 +57,7 @@ public:
      * @param state node state.
      * @return Error.
      */
-    virtual Error OnNodeStateChanged(const String& nodeID, const NodeStateObsolete& state) = 0;
+    virtual Error OnNodeStateChanged(const String& nodeID, const NodeState& state) = 0;
 
     /**
      * Destructor.
@@ -76,7 +76,7 @@ public:
      * @param[out] nodeInfo node info
      * @return Error
      */
-    virtual Error GetNodeInfo(NodeInfoObsolete& nodeInfo) const = 0;
+    virtual Error GetNodeInfo(NodeInfo& nodeInfo) const = 0;
 
     /**
      * Sets the node state.
@@ -84,7 +84,7 @@ public:
      * @param state node state.
      * @return Error.
      */
-    virtual Error SetNodeState(const NodeStateObsolete& state) = 0;
+    virtual Error SetNodeState(const NodeState& state) = 0;
 
     /**
      * Subscribes on node state changed event.

--- a/src/core/iam/nodeinfoprovider/nodeinfoprovider.hpp
+++ b/src/core/iam/nodeinfoprovider/nodeinfoprovider.hpp
@@ -82,9 +82,10 @@ public:
      * Sets the node state.
      *
      * @param state node state.
+     * @param provisioned node provisioned flag.
      * @return Error.
      */
-    virtual Error SetNodeState(const NodeState& state) = 0;
+    virtual Error SetNodeState(const NodeState& state, bool provisioned) = 0;
 
     /**
      * Subscribes on node state changed event.

--- a/src/core/iam/nodeinfoprovider/nodeinfoprovider.hpp
+++ b/src/core/iam/nodeinfoprovider/nodeinfoprovider.hpp
@@ -29,26 +29,6 @@ static constexpr auto cAttrAosComponents = "AosComponents";
 static constexpr auto cAttrNodeRunners = "NodeRunners";
 
 /**
- * Aos component cm.
- */
-static constexpr auto cAosComponentCM = "cm";
-
-/**
- * Aos component iam.
- */
-static constexpr auto cAosComponentIAM = "iam";
-
-/**
- * Aos component sm.
- */
-static constexpr auto cAosComponentSM = "sm";
-
-/**
- * Aos component um.
- */
-static constexpr auto cAosComponentUM = "um";
-
-/**
  * Checks if the node is the main node.
  *
  * @param nodeInfo node info.

--- a/src/core/iam/nodeinfoprovider/tests/nodeinfoprovider.cpp
+++ b/src/core/iam/nodeinfoprovider/tests/nodeinfoprovider.cpp
@@ -10,7 +10,8 @@
 #include <core/iam/nodeinfoprovider/nodeinfoprovider.hpp>
 
 using namespace testing;
-using namespace aos::iam::nodeinfoprovider;
+
+namespace aos::iam::nodeinfoprovider {
 
 /***********************************************************************************************************************
  * Suite
@@ -24,14 +25,14 @@ class NodeInfoProviderTest : public testing::Test { };
 
 TEST_F(NodeInfoProviderTest, IsMainNodeReturnsFalseOnEmptyAttrs)
 {
-    aos::NodeInfoObsolete nodeInfo;
+    NodeInfo nodeInfo;
 
     EXPECT_FALSE(IsMainNode(nodeInfo)) << "Node has no main node attribute";
 }
 
 TEST_F(NodeInfoProviderTest, IsMainNodeReturnsTrue)
 {
-    aos::NodeInfoObsolete nodeInfo;
+    NodeInfo nodeInfo;
 
     nodeInfo.mAttrs.PushBack({"MainNode", ""});
 
@@ -40,7 +41,7 @@ TEST_F(NodeInfoProviderTest, IsMainNodeReturnsTrue)
 
 TEST_F(NodeInfoProviderTest, IsMainNodeReturnsTrueCaseInsensitive)
 {
-    aos::NodeInfoObsolete nodeInfo;
+    NodeInfo nodeInfo;
 
     nodeInfo.mAttrs.PushBack({"mainNODE", ""});
 
@@ -49,11 +50,13 @@ TEST_F(NodeInfoProviderTest, IsMainNodeReturnsTrueCaseInsensitive)
 
 TEST_F(NodeInfoProviderTest, ContainsComponent)
 {
-    aos::NodeInfo nodeInfo;
+    NodeInfo nodeInfo;
 
     nodeInfo.mAttrs.PushBack({cAttrAosComponents, "cm,sm"});
 
-    EXPECT_TRUE(ContainsComponent(nodeInfo, aos::CoreComponentEnum::eCM)) << "Node has component CM";
-    EXPECT_TRUE(ContainsComponent(nodeInfo, aos::CoreComponentEnum::eSM)) << "Node has component SM";
-    EXPECT_FALSE(ContainsComponent(nodeInfo, aos::CoreComponentEnum::eIAM)) << "Node has no component IAM";
+    EXPECT_TRUE(ContainsComponent(nodeInfo, CoreComponentEnum::eCM)) << "Node has component CM";
+    EXPECT_TRUE(ContainsComponent(nodeInfo, CoreComponentEnum::eSM)) << "Node has component SM";
+    EXPECT_FALSE(ContainsComponent(nodeInfo, CoreComponentEnum::eIAM)) << "Node has no component IAM";
 }
+
+} // namespace aos::iam::nodeinfoprovider

--- a/src/core/iam/nodemanager/nodemanager.cpp
+++ b/src/core/iam/nodemanager/nodemanager.cpp
@@ -62,24 +62,26 @@ Error NodeManager::SetNodeInfo(const NodeInfo& info)
     return UpdateNodeInfo(info);
 }
 
-Error NodeManager::SetNodeState(const String& nodeID, const NodeState& state)
+Error NodeManager::SetNodeState(const String& nodeID, const NodeState& state, bool provisioned)
 {
     LockGuard lock {mMutex};
 
-    LOG_DBG() << "Set node state" << Log::Field("nodeID", nodeID) << Log::Field("state", state);
+    LOG_DBG() << "Set node state" << Log::Field("nodeID", nodeID) << Log::Field("state", state)
+              << Log::Field("provisioned", provisioned);
 
     auto nodeInfo = MakeUnique<NodeInfo>(&mAllocator);
 
     if (const auto* cachedInfo = GetNodeFromCache(nodeID); cachedInfo != nullptr) {
-        if (cachedInfo->mState == state) {
+        if (cachedInfo->mState == state && cachedInfo->mProvisioned == provisioned) {
             return ErrorEnum::eNone;
         }
 
         *nodeInfo = *cachedInfo;
     }
 
-    nodeInfo->mNodeID = nodeID;
-    nodeInfo->mState  = state;
+    nodeInfo->mNodeID      = nodeID;
+    nodeInfo->mState       = state;
+    nodeInfo->mProvisioned = provisioned;
 
     return UpdateNodeInfo(*nodeInfo);
 }

--- a/src/core/iam/nodemanager/nodemanager.hpp
+++ b/src/core/iam/nodemanager/nodemanager.hpp
@@ -10,7 +10,7 @@
 
 #include <core/common/tools/memory.hpp>
 #include <core/common/tools/thread.hpp>
-#include <core/common/types/obsolete.hpp>
+#include <core/common/types/common.hpp>
 #include <core/iam/config.hpp>
 
 namespace aos::iam::nodemanager {
@@ -29,7 +29,7 @@ public:
      *
      * @param info node info.
      */
-    virtual void OnNodeInfoChange(const NodeInfoObsolete& info) = 0;
+    virtual void OnNodeInfoChange(const NodeInfo& info) = 0;
 
     /**
      * Node info removed notification.
@@ -55,7 +55,7 @@ public:
      * @param info node info.
      * @return Error.
      */
-    virtual Error SetNodeInfo(const NodeInfoObsolete& info) = 0;
+    virtual Error SetNodeInfo(const NodeInfo& info) = 0;
 
     /**
      * Updates node state.
@@ -64,7 +64,7 @@ public:
      * @param state node state.
      * @return Error.
      */
-    virtual Error SetNodeState(const String& nodeID, NodeStateObsolete state) = 0;
+    virtual Error SetNodeState(const String& nodeID, const NodeState& state) = 0;
 
     /**
      * Returns node info.
@@ -73,7 +73,7 @@ public:
      * @param[out] nodeInfo result node identifier.
      * @return Error.
      */
-    virtual Error GetNodeInfo(const String& nodeID, NodeInfoObsolete& nodeInfo) const = 0;
+    virtual Error GetNodeInfo(const String& nodeID, NodeInfo& nodeInfo) const = 0;
 
     /**
      * Returns ids for all the node in the manager.
@@ -116,7 +116,7 @@ public:
      * @param info node info.
      * @return Error.
      */
-    virtual Error SetNodeInfo(const NodeInfoObsolete& info) = 0;
+    virtual Error SetNodeInfo(const NodeInfo& info) = 0;
 
     /**
      * Returns node info.
@@ -125,7 +125,7 @@ public:
      * @param[out] nodeInfo result node identifier.
      * @return Error.
      */
-    virtual Error GetNodeInfo(const String& nodeID, NodeInfoObsolete& nodeInfo) const = 0;
+    virtual Error GetNodeInfo(const String& nodeID, NodeInfo& nodeInfo) const = 0;
 
     /**
      * Returns ids for all the node in the manager.
@@ -168,7 +168,7 @@ public:
      * @param info node info.
      * @return Error.
      */
-    Error SetNodeInfo(const NodeInfoObsolete& info) override;
+    Error SetNodeInfo(const NodeInfo& info) override;
 
     /**
      * Updates state for a node.
@@ -177,7 +177,7 @@ public:
      * @param state node state.
      * @return Error.
      */
-    Error SetNodeState(const String& nodeID, NodeStateObsolete state) override;
+    Error SetNodeState(const String& nodeID, const NodeState& state) override;
 
     /**
      * Returns node info.
@@ -186,7 +186,7 @@ public:
      * @param[out] nodeInfo result node identifier.
      * @return Error.
      */
-    Error GetNodeInfo(const String& nodeID, NodeInfoObsolete& nodeInfo) const override;
+    Error GetNodeInfo(const String& nodeID, NodeInfo& nodeInfo) const override;
 
     /**
      * Returns ids for all the node in the manager.
@@ -213,23 +213,20 @@ public:
     Error SubscribeNodeInfoChange(NodeInfoListenerItf& listener) override;
 
 private:
-    static constexpr auto cNodeMaxNum = AOS_CONFIG_NODEMANAGER_NODE_MAX_NUM;
-    static constexpr auto cAllocatorSize
-        = sizeof(StaticArray<StaticString<cIDLen>, cNodeMaxNum>) + sizeof(NodeInfoObsolete);
+    static constexpr auto cNodeMaxNum    = AOS_CONFIG_NODEMANAGER_NODE_MAX_NUM;
+    static constexpr auto cAllocatorSize = sizeof(StaticArray<StaticString<cIDLen>, cNodeMaxNum>) + sizeof(NodeInfo);
 
-    NodeInfoObsolete*       GetNodeFromCache(const String& nodeID);
-    const NodeInfoObsolete* GetNodeFromCache(const String& nodeID) const;
-    Error                   UpdateNodeInfo(const NodeInfoObsolete& info);
+    NodeInfo*               GetNodeFromCache(const String& nodeID);
+    const NodeInfo*         GetNodeFromCache(const String& nodeID) const;
+    Error                   UpdateNodeInfo(const NodeInfo& info);
+    Error                   UpdateCache(const NodeInfo& nodeInfo);
+    RetWithError<NodeInfo*> AddNodeInfoToCache();
+    void                    NotifyNodeInfoChange(const NodeInfo& nodeInfo);
 
-    Error UpdateCache(const NodeInfoObsolete& nodeInfo);
-
-    RetWithError<NodeInfoObsolete*> AddNodeInfoToCache();
-    void                            NotifyNodeInfoChange(const NodeInfoObsolete& nodeInfo);
-
-    NodeInfoStorageItf*                        mStorage          = nullptr;
-    NodeInfoListenerItf*                       mNodeInfoListener = nullptr;
-    StaticArray<NodeInfoObsolete, cNodeMaxNum> mNodeInfoCache;
-    mutable Mutex                              mMutex;
+    NodeInfoStorageItf*                mStorage {};
+    NodeInfoListenerItf*               mNodeInfoListener {};
+    StaticArray<NodeInfo, cNodeMaxNum> mNodeInfoCache;
+    mutable Mutex                      mMutex;
 
     StaticAllocator<cAllocatorSize> mAllocator;
 };

--- a/src/core/iam/nodemanager/nodemanager.hpp
+++ b/src/core/iam/nodemanager/nodemanager.hpp
@@ -62,9 +62,10 @@ public:
      *
      * @param nodeID node identifier.
      * @param state node state.
+     * @param provisioned node provisioned flag.
      * @return Error.
      */
-    virtual Error SetNodeState(const String& nodeID, const NodeState& state) = 0;
+    virtual Error SetNodeState(const String& nodeID, const NodeState& state, bool provisioned) = 0;
 
     /**
      * Returns node info.
@@ -175,9 +176,10 @@ public:
      *
      * @param nodeID node identifier.
      * @param state node state.
+     * @param provisioned node provisioned flag.
      * @return Error.
      */
-    Error SetNodeState(const String& nodeID, const NodeState& state) override;
+    Error SetNodeState(const String& nodeID, const NodeState& state, bool provisioned) override;
 
     /**
      * Returns node info.

--- a/src/core/iam/nodemanager/tests/nodemanager.cpp
+++ b/src/core/iam/nodemanager/tests/nodemanager.cpp
@@ -120,7 +120,7 @@ TEST_F(NodeManagerTest, SetNodeStateOffline)
     NodeStateEnum        state = NodeStateEnum::eOffline;
 
     EXPECT_CALL(mStorage, RemoveNodeInfo(node0)).WillOnce(Return(ErrorEnum::eNotFound));
-    ASSERT_TRUE(mManager.SetNodeState(node0, state).IsNone());
+    ASSERT_TRUE(mManager.SetNodeState(node0, state, false).IsNone());
 }
 
 TEST_F(NodeManagerTest, GetNodeInfoNotFound)
@@ -152,8 +152,8 @@ TEST_F(NodeManagerTest, GetAllNodeIDs)
     NodeStateEnum state = NodeStateEnum::eOnline;
 
     EXPECT_CALL(mStorage, SetNodeInfo(_)).WillRepeatedly(Return(ErrorEnum::eNone));
-    ASSERT_TRUE(mManager.SetNodeState(node0, state).IsNone());
-    ASSERT_TRUE(mManager.SetNodeState(node1, state).IsNone());
+    ASSERT_TRUE(mManager.SetNodeState(node0, state, true).IsNone());
+    ASSERT_TRUE(mManager.SetNodeState(node1, state, true).IsNone());
 
     StaticArray<StaticString<cIDLen>, 2> ids;
 
@@ -169,7 +169,7 @@ TEST_F(NodeManagerTest, RemoveNodeInfo)
     NodeStateEnum state = NodeStateEnum::eOnline;
 
     EXPECT_CALL(mStorage, SetNodeInfo(Field(&NodeInfo::mNodeID, node0))).WillOnce(Return(ErrorEnum::eNone));
-    ASSERT_TRUE(mManager.SetNodeState(node0, state).IsNone());
+    ASSERT_TRUE(mManager.SetNodeState(node0, state, true).IsNone());
 
     ASSERT_EQ(mManager.GetNodeInfo(node0, nodeInfo), ErrorEnum::eNone);
 

--- a/src/core/iam/nodemanager/tests/storagemock.hpp
+++ b/src/core/iam/nodemanager/tests/storagemock.hpp
@@ -16,8 +16,8 @@ namespace aos::iam::nodemanager {
 
 class NodeInfoStorageMock : public NodeInfoStorageItf {
 public:
-    MOCK_METHOD(Error, SetNodeInfo, (const NodeInfoObsolete& info), (override));
-    MOCK_METHOD(Error, GetNodeInfo, (const String& nodeID, NodeInfoObsolete& nodeInfo), (const, override));
+    MOCK_METHOD(Error, SetNodeInfo, (const NodeInfo& info), (override));
+    MOCK_METHOD(Error, GetNodeInfo, (const String& nodeID, NodeInfo& nodeInfo), (const, override));
     MOCK_METHOD(Error, GetAllNodeIDs, (Array<StaticString<cIDLen>> & ids), (const, override));
     MOCK_METHOD(Error, RemoveNodeInfo, (const String& nodeID), (override));
 };

--- a/src/core/iam/tests/mocks/nodeinfoprovidermock.hpp
+++ b/src/core/iam/tests/mocks/nodeinfoprovidermock.hpp
@@ -27,7 +27,7 @@ public:
 class NodeInfoProviderMock : public NodeInfoProviderItf {
 public:
     MOCK_METHOD(Error, GetNodeInfo, (NodeInfo & nodeInfo), (const, override));
-    MOCK_METHOD(Error, SetNodeState, (const NodeState& state), (override));
+    MOCK_METHOD(Error, SetNodeState, (const NodeState& state, bool provisioned), (override));
     MOCK_METHOD(Error, SubscribeNodeStateChanged, (NodeStateObserverItf & observer), (override));
     MOCK_METHOD(Error, UnsubscribeNodeStateChanged, (NodeStateObserverItf & observer), (override));
 };

--- a/src/core/iam/tests/mocks/nodeinfoprovidermock.hpp
+++ b/src/core/iam/tests/mocks/nodeinfoprovidermock.hpp
@@ -18,7 +18,7 @@ namespace aos::iam::nodeinfoprovider {
  */
 class NodeStateObserverMock : public NodeStateObserverItf {
 public:
-    MOCK_METHOD(Error, OnNodeStateChanged, (const String& nodeID, const NodeStateObsolete& state), (override));
+    MOCK_METHOD(Error, OnNodeStateChanged, (const String& nodeID, const NodeState& state), (override));
 };
 
 /**
@@ -26,8 +26,8 @@ public:
  */
 class NodeInfoProviderMock : public NodeInfoProviderItf {
 public:
-    MOCK_METHOD(Error, GetNodeInfo, (NodeInfoObsolete & nodeInfo), (const, override));
-    MOCK_METHOD(Error, SetNodeState, (const NodeStateObsolete& state), (override));
+    MOCK_METHOD(Error, GetNodeInfo, (NodeInfo & nodeInfo), (const, override));
+    MOCK_METHOD(Error, SetNodeState, (const NodeState& state), (override));
     MOCK_METHOD(Error, SubscribeNodeStateChanged, (NodeStateObserverItf & observer), (override));
     MOCK_METHOD(Error, UnsubscribeNodeStateChanged, (NodeStateObserverItf & observer), (override));
 };

--- a/src/core/iam/tests/mocks/nodemanagermock.hpp
+++ b/src/core/iam/tests/mocks/nodemanagermock.hpp
@@ -19,7 +19,7 @@ namespace aos::iam::nodemanager {
 class NodeManagerMock : public NodeManagerItf {
 public:
     MOCK_METHOD(Error, SetNodeInfo, (const NodeInfo&), (override));
-    MOCK_METHOD(Error, SetNodeState, (const String&, const NodeState&), (override));
+    MOCK_METHOD(Error, SetNodeState, (const String&, const NodeState&, bool provisioned), (override));
     MOCK_METHOD(Error, GetNodeInfo, (const String&, NodeInfo&), (const, override));
     MOCK_METHOD(Error, GetAllNodeIDs, (Array<StaticString<cIDLen>>&), (const, override));
     MOCK_METHOD(Error, RemoveNodeInfo, (const String&), (override));

--- a/src/core/iam/tests/mocks/nodemanagermock.hpp
+++ b/src/core/iam/tests/mocks/nodemanagermock.hpp
@@ -18,9 +18,9 @@ namespace aos::iam::nodemanager {
  */
 class NodeManagerMock : public NodeManagerItf {
 public:
-    MOCK_METHOD(Error, SetNodeInfo, (const NodeInfoObsolete&), (override));
-    MOCK_METHOD(Error, SetNodeState, (const String&, NodeStateObsolete), (override));
-    MOCK_METHOD(Error, GetNodeInfo, (const String&, NodeInfoObsolete&), (const, override));
+    MOCK_METHOD(Error, SetNodeInfo, (const NodeInfo&), (override));
+    MOCK_METHOD(Error, SetNodeState, (const String&, const NodeState&), (override));
+    MOCK_METHOD(Error, GetNodeInfo, (const String&, NodeInfo&), (const, override));
     MOCK_METHOD(Error, GetAllNodeIDs, (Array<StaticString<cIDLen>>&), (const, override));
     MOCK_METHOD(Error, RemoveNodeInfo, (const String&), (override));
     MOCK_METHOD(Error, SubscribeNodeInfoChange, (NodeInfoListenerItf&), (override));

--- a/src/core/sm/launcher/instance.cpp
+++ b/src/core/sm/launcher/instance.cpp
@@ -33,7 +33,7 @@ Instance::Instance(const InstanceInfo& instanceInfo, const String& instanceID,
     layermanager::LayerManagerItf& layerManager, resourcemanager::ResourceManagerItf& resourceManager,
     networkmanager::NetworkManagerItf& networkmanager, iamclient::PermHandlerItf& permHandler,
     runner::RunnerItf& runner, RuntimeItf& runtime, monitoring::ResourceMonitorItf& resourceMonitor,
-    oci::OCISpecItf& ociManager, const String& hostWhiteoutsDir, const NodeInfoObsolete& nodeInfo)
+    oci::OCISpecItf& ociManager, const String& hostWhiteoutsDir, const NodeInfo& nodeInfo)
     : mInstanceID(instanceID)
     , mInstanceInfo(instanceInfo)
     , mService(service)

--- a/src/core/sm/launcher/instance.hpp
+++ b/src/core/sm/launcher/instance.hpp
@@ -157,7 +157,7 @@ public:
         layermanager::LayerManagerItf& layerManager, resourcemanager::ResourceManagerItf& resourceManager,
         networkmanager::NetworkManagerItf& networkManager, iamclient::PermHandlerItf& permHandler,
         runner::RunnerItf& runner, RuntimeItf& runtime, monitoring::ResourceMonitorItf& resourceMonitor,
-        oci::OCISpecItf& ociManager, const String& hostWhiteoutsDir, const NodeInfoObsolete& nodeInfo);
+        oci::OCISpecItf& ociManager, const String& hostWhiteoutsDir, const NodeInfo& nodeInfo);
 
     /**
      * Starts instance.
@@ -387,7 +387,7 @@ private:
     monitoring::ResourceMonitorItf&      mResourceMonitor;
     oci::OCISpecItf&                     mOCIManager;
     const String&                        mHostWhiteoutsDir;
-    const NodeInfoObsolete&              mNodeInfo;
+    const NodeInfo&                      mNodeInfo;
 
     StaticString<cFilePathLen> mRuntimeDir;
     InstanceState              mState;

--- a/src/core/sm/launcher/launcher.hpp
+++ b/src/core/sm/launcher/launcher.hpp
@@ -430,7 +430,7 @@ private:
     StaticList<Instance, cMaxNumInstances> mCurrentInstances;
     EnvVarsInstanceInfoArray               mCurrentEnvVars;
     StaticString<cFilePathLen>             mHostWhiteoutsDir;
-    NodeInfoObsolete                       mNodeInfo;
+    NodeInfo                               mNodeInfo;
     Time                                   mOnlineTime;
     Timer                                  mTimer;
 };


### PR DESCRIPTION
This patch adds config.hpp for the fileidentifier module and introduces a dedicated namespace for fileidentifier module.