### PR TITLE
cm: launcher: fix compilation issues

### DIFF
--- a/src/core/cm/launcher/balancer.cpp
+++ b/src/core/cm/launcher/balancer.cpp
@@ -15,7 +15,7 @@ namespace aos::cm::launcher {
  **********************************************************************************************************************/
 
 void Balancer::Init(InstanceManager& instanceManager, imagemanager::ItemInfoProviderItf& itemInfoProvider,
-    imagemanager::BlobInfoProviderItf& blobInfoProvider, oci::OCISpecItf& ociSpec, NodeManager& nodeManager,
+    blobinfoprovider::ProviderItf& blobInfoProvider, oci::OCISpecItf& ociSpec, NodeManager& nodeManager,
     MonitoringProviderItf& monitorProvider, InstanceRunnerItf& runner,
     networkmanager::NetworkManagerItf& networkManager)
 {
@@ -95,7 +95,8 @@ Error Balancer::PerformNodeBalancing(const Array<RunInstanceRequest>& requests)
 {
     for (const auto& request : requests) {
         for (size_t i = 0; i < request.mNumInstances; i++) {
-            InstanceIdent instanceIdent {request.mItemID, request.mSubjectInfo.mSubjectID, i};
+            InstanceIdent instanceIdent {
+                request.mItemID, request.mSubjectInfo.mSubjectID, i, UpdateItemTypeEnum::eService};
             if (mNodeManager->IsScheduled(instanceIdent)) {
                 continue;
             }
@@ -580,7 +581,8 @@ Error Balancer::PerformPolicyBalancing(const Array<RunInstanceRequest>& requests
         }
 
         for (size_t i = 0; i < request.mNumInstances; i++) {
-            InstanceIdent instanceIdent {request.mItemID, request.mSubjectInfo.mSubjectID, i};
+            InstanceIdent instanceIdent {
+                request.mItemID, request.mSubjectInfo.mSubjectID, i, UpdateItemTypeEnum::eService};
 
             if (!mNodeManager->IsRunning(instanceIdent)) {
                 continue;

--- a/src/core/cm/launcher/balancer.hpp
+++ b/src/core/cm/launcher/balancer.hpp
@@ -39,7 +39,7 @@ public:
      * @param networkManager network manager.
      */
     void Init(InstanceManager& instanceManager, imagemanager::ItemInfoProviderItf& itemInfoProvider,
-        imagemanager::BlobInfoProviderItf& blobInfoProvider, oci::OCISpecItf& ociSpec, NodeManager& nodeManager,
+        blobinfoprovider::ProviderItf& blobInfoProvider, oci::OCISpecItf& ociSpec, NodeManager& nodeManager,
         MonitoringProviderItf& monitorProvider, InstanceRunnerItf& runner,
         networkmanager::NetworkManagerItf& networkManager);
 

--- a/src/core/cm/launcher/imageinfoprovider.cpp
+++ b/src/core/cm/launcher/imageinfoprovider.cpp
@@ -12,7 +12,7 @@
 namespace aos::cm::launcher {
 
 void ImageInfoProvider::Init(imagemanager::ItemInfoProviderItf& itemInfoProvider,
-    imagemanager::BlobInfoProviderItf& blobInfoProvider, oci::OCISpecItf& ociSpec)
+    blobinfoprovider::ProviderItf& blobInfoProvider, oci::OCISpecItf& ociSpec)
 {
     mItemInfoProvider = &itemInfoProvider;
     mBlobInfoProvider = &blobInfoProvider;

--- a/src/core/cm/launcher/imageinfoprovider.hpp
+++ b/src/core/cm/launcher/imageinfoprovider.hpp
@@ -7,8 +7,8 @@
 #ifndef AOS_CORE_CM_LAUNCHER_IMAGEINFOPROVIDER_HPP_
 #define AOS_CORE_CM_LAUNCHER_IMAGEINFOPROVIDER_HPP_
 
-#include <core/cm/imagemanager/itf/blobinfoprovider.hpp>
 #include <core/cm/imagemanager/itf/iteminfoprovider.hpp>
+#include <core/common/blobinfoprovider/itf/blobinfoprovider.hpp>
 #include <core/common/ocispec/itf/ocispec.hpp>
 #include <core/common/tools/array.hpp>
 #include <core/common/tools/error.hpp>
@@ -29,7 +29,7 @@ public:
      * @param blobInfoProvider blob info provider.
      * @param ociSpec OCI spec.
      */
-    void Init(imagemanager::ItemInfoProviderItf& itemInfoProvider, imagemanager::BlobInfoProviderItf& blobInfoProvider,
+    void Init(imagemanager::ItemInfoProviderItf& itemInfoProvider, blobinfoprovider::ProviderItf& blobInfoProvider,
         oci::OCISpecItf& ociSpec);
 
     /**
@@ -66,7 +66,7 @@ private:
         + sizeof(StaticString<oci::cDigestLen>);
 
     imagemanager::ItemInfoProviderItf* mItemInfoProvider {};
-    imagemanager::BlobInfoProviderItf* mBlobInfoProvider {};
+    blobinfoprovider::ProviderItf*     mBlobInfoProvider {};
     oci::OCISpecItf*                   mOCISpec {};
 
     StaticAllocator<cAllocatorSize> mAllocator;

--- a/src/core/cm/launcher/instancemanager.cpp
+++ b/src/core/cm/launcher/instancemanager.cpp
@@ -15,7 +15,7 @@ namespace aos::cm::launcher {
  **********************************************************************************************************************/
 
 Error InstanceManager::Init(const Config& config, StorageItf& storage, storagestate::StorageStateItf& storageState,
-    imagemanager::ItemInfoProviderItf& itemInfoProvider, imagemanager::BlobInfoProviderItf& blobInfoProvider,
+    imagemanager::ItemInfoProviderItf& itemInfoProvider, blobinfoprovider::ProviderItf& blobInfoProvider,
     oci::OCISpecItf& ociSpec, IDValidator gidValidator, IDValidator uidValidator)
 {
     mConfig       = config;

--- a/src/core/cm/launcher/instancemanager.hpp
+++ b/src/core/cm/launcher/instancemanager.hpp
@@ -7,9 +7,9 @@
 #ifndef AOS_CORE_CM_LAUNCHER_INSTANCEMANAGER_HPP_
 #define AOS_CORE_CM_LAUNCHER_INSTANCEMANAGER_HPP_
 
-#include <core/cm/imagemanager/itf/blobinfoprovider.hpp>
 #include <core/cm/imagemanager/itf/iteminfoprovider.hpp>
 #include <core/cm/storagestate/storagestate.hpp>
+#include <core/common/blobinfoprovider/itf/blobinfoprovider.hpp>
 #include <core/common/instancestatusprovider/itf/instancestatusprovider.hpp>
 #include <core/common/monitoring/itf/monitoringdata.hpp>
 #include <core/common/ocispec/itf/ocispec.hpp>
@@ -55,7 +55,7 @@ public:
      * @return Error.
      */
     Error Init(const Config& config, StorageItf& storage, storagestate::StorageStateItf& storageState,
-        imagemanager::ItemInfoProviderItf& itemInfoProvider, imagemanager::BlobInfoProviderItf& blobInfoProvider,
+        imagemanager::ItemInfoProviderItf& itemInfoProvider, blobinfoprovider::ProviderItf& blobInfoProvider,
         oci::OCISpecItf& ociSpec, IDValidator gidValidator, IDValidator uidValidator);
 
     /**

--- a/src/core/cm/launcher/launcher.cpp
+++ b/src/core/cm/launcher/launcher.cpp
@@ -16,7 +16,7 @@ namespace aos::cm::launcher {
 
 Error Launcher::Init(const Config& config, StorageItf& storage, nodeinfoprovider::NodeInfoProviderItf& nodeInfoProvider,
     InstanceRunnerItf& runner, imagemanager::ItemInfoProviderItf& itemInfoProvider,
-    imagemanager::BlobInfoProviderItf& blobInfoProvider, oci::OCISpecItf& ociSpec,
+    blobinfoprovider::ProviderItf& blobInfoProvider, oci::OCISpecItf& ociSpec,
     unitconfig::NodeConfigProviderItf& nodeConfigProvider, storagestate::StorageStateItf& storageState,
     networkmanager::NetworkManagerItf& networkManager, MonitoringProviderItf& monitorProvider, IDValidator gidValidator,
     IDValidator uidValidator)

--- a/src/core/cm/launcher/launcher.hpp
+++ b/src/core/cm/launcher/launcher.hpp
@@ -7,10 +7,10 @@
 #ifndef AOS_CORE_CM_LAUNCHER_LAUNCHER_HPP_
 #define AOS_CORE_CM_LAUNCHER_LAUNCHER_HPP_
 
-#include <core/cm/imagemanager/itf/blobinfoprovider.hpp>
 #include <core/cm/imagemanager/itf/iteminfoprovider.hpp>
 #include <core/cm/storagestate/itf/storagestate.hpp>
 #include <core/cm/unitconfig/itf/nodeconfigprovider.hpp>
+#include <core/common/blobinfoprovider/itf/blobinfoprovider.hpp>
 #include <core/common/ocispec/itf/ocispec.hpp>
 
 #include "itf/instancestatusreceiver.hpp"
@@ -50,7 +50,7 @@ public:
      */
     Error Init(const Config& config, StorageItf& storage, nodeinfoprovider::NodeInfoProviderItf& nodeInfoProvider,
         InstanceRunnerItf& runner, imagemanager::ItemInfoProviderItf& itemInfoProvider,
-        imagemanager::BlobInfoProviderItf& blobInfoProvider, oci::OCISpecItf& ociSpec,
+        blobinfoprovider::ProviderItf& blobInfoProvider, oci::OCISpecItf& ociSpec,
         unitconfig::NodeConfigProviderItf& nodeConfigProvider, storagestate::StorageStateItf& storageState,
         networkmanager::NetworkManagerItf& networkManager, MonitoringProviderItf& monitorProvider,
         IDValidator gidValidator, IDValidator uidValidator);

--- a/src/core/cm/launcher/tests/launcher.cpp
+++ b/src/core/cm/launcher/tests/launcher.cpp
@@ -199,7 +199,7 @@ InstanceStatus CreateInstanceStatus(const InstanceIdent& instance, const std::st
 
 InstanceIdent CreateInstanceIdent(const std::string& itemID, const std::string& subjectID = "", uint64_t instance = 0)
 {
-    return InstanceIdent {itemID.c_str(), subjectID.c_str(), instance};
+    return InstanceIdent {itemID.c_str(), subjectID.c_str(), instance, UpdateItemTypeEnum::eService};
 }
 
 RunInstanceRequest CreateRunRequest(const std::string& itemID, const std::string& subjectID = "", uint64_t priority = 0,
@@ -828,7 +828,8 @@ TEST_F(CMLauncherTest, Components)
 
     // Check run status
     StaticArray<InstanceStatus, cMaxNumInstances> expectedRunStatus;
-    expectedRunStatus.PushBack(CreateInstanceStatus({cComponent1, cSubject1, 0}, cNodeIDRemoteSM1, cRunnerRootfs));
+    expectedRunStatus.PushBack(CreateInstanceStatus(
+        {cComponent1, cSubject1, 0, UpdateItemTypeEnum::eService}, cNodeIDRemoteSM1, cRunnerRootfs));
 
     Array<InstanceStatus> componentStatuses(expectedRunStatus.begin(), expectedRunStatus.Size());
     ExpectInstanceStatusesMatch(instanceStatusListener.GetLastStatuses(), componentStatuses);
@@ -900,12 +901,18 @@ TestDataPtr TestItemNodePriority()
     testData->mExpectedRunRequests[cNodeIDRunxSM].mStartInstances = runxSMRequests;
 
     // Expected run status
-    testData->mExpectedRunStatus.PushBack(CreateInstanceStatus({cService1, cSubject1, 0}, cNodeIDLocalSM, cRunnerRunc));
-    testData->mExpectedRunStatus.PushBack(CreateInstanceStatus({cService1, cSubject1, 1}, cNodeIDLocalSM, cRunnerRunc));
-    testData->mExpectedRunStatus.PushBack(CreateInstanceStatus({cService2, cSubject1, 0}, cNodeIDLocalSM, cRunnerRunc));
-    testData->mExpectedRunStatus.PushBack(CreateInstanceStatus({cService2, cSubject1, 1}, cNodeIDLocalSM, cRunnerRunc));
-    testData->mExpectedRunStatus.PushBack(CreateInstanceStatus({cService3, cSubject1, 0}, cNodeIDRunxSM, cRunnerRunx));
-    testData->mExpectedRunStatus.PushBack(CreateInstanceStatus({cService3, cSubject1, 1}, cNodeIDRunxSM, cRunnerRunx));
+    testData->mExpectedRunStatus.PushBack(
+        CreateInstanceStatus({cService1, cSubject1, 0, UpdateItemTypeEnum::eService}, cNodeIDLocalSM, cRunnerRunc));
+    testData->mExpectedRunStatus.PushBack(
+        CreateInstanceStatus({cService1, cSubject1, 1, UpdateItemTypeEnum::eService}, cNodeIDLocalSM, cRunnerRunc));
+    testData->mExpectedRunStatus.PushBack(
+        CreateInstanceStatus({cService2, cSubject1, 0, UpdateItemTypeEnum::eService}, cNodeIDLocalSM, cRunnerRunc));
+    testData->mExpectedRunStatus.PushBack(
+        CreateInstanceStatus({cService2, cSubject1, 1, UpdateItemTypeEnum::eService}, cNodeIDLocalSM, cRunnerRunc));
+    testData->mExpectedRunStatus.PushBack(
+        CreateInstanceStatus({cService3, cSubject1, 0, UpdateItemTypeEnum::eService}, cNodeIDRunxSM, cRunnerRunx));
+    testData->mExpectedRunStatus.PushBack(
+        CreateInstanceStatus({cService3, cSubject1, 1, UpdateItemTypeEnum::eService}, cNodeIDRunxSM, cRunnerRunx));
 
     return testData;
 }
@@ -954,15 +961,17 @@ TestDataPtr TestItemLabels()
 
     // Expected run status
     testData->mExpectedRunStatus.PushBack(
-        CreateInstanceStatus({cService1, cSubject1, 0}, cNodeIDRemoteSM1, cRunnerRunc));
+        CreateInstanceStatus({cService1, cSubject1, 0, UpdateItemTypeEnum::eService}, cNodeIDRemoteSM1, cRunnerRunc));
     testData->mExpectedRunStatus.PushBack(
-        CreateInstanceStatus({cService1, cSubject1, 1}, cNodeIDRemoteSM1, cRunnerRunc));
-    testData->mExpectedRunStatus.PushBack(CreateInstanceStatus({cService2, cSubject1, 0}, cNodeIDLocalSM, cRunnerRunc));
-    testData->mExpectedRunStatus.PushBack(CreateInstanceStatus({cService2, cSubject1, 1}, cNodeIDLocalSM, cRunnerRunc));
-    testData->mExpectedRunStatus.PushBack(CreateInstanceStatus({cService3, cSubject1, 0}, "", "",
-        InstanceStateEnum::eFailed, Error(ErrorEnum::eNotFound, "no nodes with instance labels")));
-    testData->mExpectedRunStatus.PushBack(CreateInstanceStatus({cService3, cSubject1, 1}, "", "",
-        InstanceStateEnum::eFailed, Error(ErrorEnum::eNotFound, "no nodes with instance labels")));
+        CreateInstanceStatus({cService1, cSubject1, 1, UpdateItemTypeEnum::eService}, cNodeIDRemoteSM1, cRunnerRunc));
+    testData->mExpectedRunStatus.PushBack(
+        CreateInstanceStatus({cService2, cSubject1, 0, UpdateItemTypeEnum::eService}, cNodeIDLocalSM, cRunnerRunc));
+    testData->mExpectedRunStatus.PushBack(
+        CreateInstanceStatus({cService2, cSubject1, 1, UpdateItemTypeEnum::eService}, cNodeIDLocalSM, cRunnerRunc));
+    testData->mExpectedRunStatus.PushBack(CreateInstanceStatus({cService3, cSubject1, 0, UpdateItemTypeEnum::eService},
+        "", "", InstanceStateEnum::eFailed, Error(ErrorEnum::eNotFound, "no nodes with instance labels")));
+    testData->mExpectedRunStatus.PushBack(CreateInstanceStatus({cService3, cSubject1, 1, UpdateItemTypeEnum::eService},
+        "", "", InstanceStateEnum::eFailed, Error(ErrorEnum::eNotFound, "no nodes with instance labels")));
 
     return testData;
 }
@@ -1016,13 +1025,17 @@ TestDataPtr TestItemResources()
 
     // Expected run status
     testData->mExpectedRunStatus.PushBack(
-        CreateInstanceStatus({cService1, cSubject1, 0}, cNodeIDRemoteSM1, cRunnerRunc));
+        CreateInstanceStatus({cService1, cSubject1, 0, UpdateItemTypeEnum::eService}, cNodeIDRemoteSM1, cRunnerRunc));
     testData->mExpectedRunStatus.PushBack(
-        CreateInstanceStatus({cService1, cSubject1, 1}, cNodeIDRemoteSM1, cRunnerRunc));
-    testData->mExpectedRunStatus.PushBack(CreateInstanceStatus({cService2, cSubject1, 0}, cNodeIDLocalSM, cRunnerRunc));
-    testData->mExpectedRunStatus.PushBack(CreateInstanceStatus({cService2, cSubject1, 1}, cNodeIDLocalSM, cRunnerRunc));
-    testData->mExpectedRunStatus.PushBack(CreateInstanceStatus({cService3, cSubject1, 0}, cNodeIDLocalSM, cRunnerRunc));
-    testData->mExpectedRunStatus.PushBack(CreateInstanceStatus({cService3, cSubject1, 1}, cNodeIDLocalSM, cRunnerRunc));
+        CreateInstanceStatus({cService1, cSubject1, 1, UpdateItemTypeEnum::eService}, cNodeIDRemoteSM1, cRunnerRunc));
+    testData->mExpectedRunStatus.PushBack(
+        CreateInstanceStatus({cService2, cSubject1, 0, UpdateItemTypeEnum::eService}, cNodeIDLocalSM, cRunnerRunc));
+    testData->mExpectedRunStatus.PushBack(
+        CreateInstanceStatus({cService2, cSubject1, 1, UpdateItemTypeEnum::eService}, cNodeIDLocalSM, cRunnerRunc));
+    testData->mExpectedRunStatus.PushBack(
+        CreateInstanceStatus({cService3, cSubject1, 0, UpdateItemTypeEnum::eService}, cNodeIDLocalSM, cRunnerRunc));
+    testData->mExpectedRunStatus.PushBack(
+        CreateInstanceStatus({cService3, cSubject1, 1, UpdateItemTypeEnum::eService}, cNodeIDLocalSM, cRunnerRunc));
 
     return testData;
 }
@@ -1054,10 +1067,12 @@ TestDataPtr TestItemStorageRatio()
 
         if (i < 3) {
             testData->mExpectedRunStatus.PushBack(
-                CreateInstanceStatus({cService1, cSubject1, static_cast<uint64_t>(i)}, cNodeIDLocalSM, cRunnerRunc));
+                CreateInstanceStatus({cService1, cSubject1, static_cast<uint64_t>(i), UpdateItemTypeEnum::eService},
+                    cNodeIDLocalSM, cRunnerRunc));
         } else {
-            testData->mExpectedRunStatus.PushBack(CreateInstanceStatus({cService1, cSubject1, static_cast<uint64_t>(i)},
-                cNodeIDLocalSM, cRunnerRunc, InstanceStateEnum::eFailed, Error(ErrorEnum::eNoMemory)));
+            testData->mExpectedRunStatus.PushBack(
+                CreateInstanceStatus({cService1, cSubject1, static_cast<uint64_t>(i), UpdateItemTypeEnum::eService},
+                    cNodeIDLocalSM, cRunnerRunc, InstanceStateEnum::eFailed, Error(ErrorEnum::eNoMemory)));
         }
     }
 
@@ -1094,10 +1109,12 @@ TestDataPtr TestItemStateRatio()
 
         if (i < 3) {
             testData->mExpectedRunStatus.PushBack(
-                CreateInstanceStatus({cService1, cSubject1, static_cast<uint64_t>(i)}, cNodeIDLocalSM, cRunnerRunc));
+                CreateInstanceStatus({cService1, cSubject1, static_cast<uint64_t>(i), UpdateItemTypeEnum::eService},
+                    cNodeIDLocalSM, cRunnerRunc));
         } else {
-            testData->mExpectedRunStatus.PushBack(CreateInstanceStatus({cService1, cSubject1, static_cast<uint64_t>(i)},
-                cNodeIDLocalSM, cRunnerRunc, InstanceStateEnum::eFailed, Error(ErrorEnum::eNoMemory)));
+            testData->mExpectedRunStatus.PushBack(
+                CreateInstanceStatus({cService1, cSubject1, static_cast<uint64_t>(i), UpdateItemTypeEnum::eService},
+                    cNodeIDLocalSM, cRunnerRunc, InstanceStateEnum::eFailed, Error(ErrorEnum::eNoMemory)));
         }
     }
 
@@ -1134,10 +1151,12 @@ TestDataPtr TestItemCpuRatio()
 
         if (i < 3) {
             testData->mExpectedRunStatus.PushBack(
-                CreateInstanceStatus({cService1, cSubject1, static_cast<uint64_t>(i)}, cNodeIDLocalSM, cRunnerRunc));
+                CreateInstanceStatus({cService1, cSubject1, static_cast<uint64_t>(i), UpdateItemTypeEnum::eService},
+                    cNodeIDLocalSM, cRunnerRunc));
         } else {
-            testData->mExpectedRunStatus.PushBack(CreateInstanceStatus({cService1, cSubject1, static_cast<uint64_t>(i)},
-                cNodeIDLocalSM, cRunnerRunc, InstanceStateEnum::eFailed, Error(ErrorEnum::eFailed)));
+            testData->mExpectedRunStatus.PushBack(
+                CreateInstanceStatus({cService1, cSubject1, static_cast<uint64_t>(i), UpdateItemTypeEnum::eService},
+                    cNodeIDLocalSM, cRunnerRunc, InstanceStateEnum::eFailed, Error(ErrorEnum::eFailed)));
         }
     }
 
@@ -1174,10 +1193,12 @@ TestDataPtr TestItemRamRatio()
 
         if (i < 3) {
             testData->mExpectedRunStatus.PushBack(
-                CreateInstanceStatus({cService1, cSubject1, static_cast<uint64_t>(i)}, cNodeIDLocalSM, cRunnerRunc));
+                CreateInstanceStatus({cService1, cSubject1, static_cast<uint64_t>(i), UpdateItemTypeEnum::eService},
+                    cNodeIDLocalSM, cRunnerRunc));
         } else {
-            testData->mExpectedRunStatus.PushBack(CreateInstanceStatus({cService1, cSubject1, static_cast<uint64_t>(i)},
-                cNodeIDLocalSM, cRunnerRunc, InstanceStateEnum::eFailed, Error(ErrorEnum::eFailed)));
+            testData->mExpectedRunStatus.PushBack(
+                CreateInstanceStatus({cService1, cSubject1, static_cast<uint64_t>(i), UpdateItemTypeEnum::eService},
+                    cNodeIDLocalSM, cRunnerRunc, InstanceStateEnum::eFailed, Error(ErrorEnum::eFailed)));
         }
     }
 
@@ -1224,17 +1245,20 @@ TestDataPtr TestItemRebalancing()
         CreateAosInstanceInfo(CreateInstanceIdent(cService3, cSubject1, 0), cImageID1, cRunnerRunc, 5002, "4", 50));
 
     // Expected run status
-    testData->mExpectedRunStatus.PushBack(CreateInstanceStatus({cService1, cSubject1, 0}, cNodeIDLocalSM, cRunnerRunc));
-    testData->mExpectedRunStatus.PushBack(CreateInstanceStatus({cService2, cSubject1, 0}, cNodeIDLocalSM, cRunnerRunc));
-    testData->mExpectedRunStatus.PushBack(CreateInstanceStatus({cService3, cSubject1, 0}, cNodeIDLocalSM, cRunnerRunc));
+    testData->mExpectedRunStatus.PushBack(
+        CreateInstanceStatus({cService1, cSubject1, 0, UpdateItemTypeEnum::eService}, cNodeIDLocalSM, cRunnerRunc));
+    testData->mExpectedRunStatus.PushBack(
+        CreateInstanceStatus({cService2, cSubject1, 0, UpdateItemTypeEnum::eService}, cNodeIDLocalSM, cRunnerRunc));
+    testData->mExpectedRunStatus.PushBack(
+        CreateInstanceStatus({cService3, cSubject1, 0, UpdateItemTypeEnum::eService}, cNodeIDLocalSM, cRunnerRunc));
 
     testData->mExpectedRunRequests.clear();
     testData->mExpectedRunStatus.Clear();
 
     // Monitoring data
     CreateNodeMonitoring(testData->mMonitoring[cNodeIDLocalSM], cNodeIDLocalSM, 1000,
-        {CreateInstanceMonitoring(InstanceIdent {cService1, cSubject1, 0}, 500),
-            CreateInstanceMonitoring(InstanceIdent {cService2, cSubject1, 0}, 500)});
+        {CreateInstanceMonitoring(InstanceIdent {cService1, cSubject1, 0, UpdateItemTypeEnum::eService}, 500),
+            CreateInstanceMonitoring(InstanceIdent {cService2, cSubject1, 0, UpdateItemTypeEnum::eService}, 500)});
 
     return testData;
 }
@@ -1275,17 +1299,20 @@ TestDataPtr TestItemRebalancingPolicy()
         CreateAosInstanceInfo(CreateInstanceIdent(cService3, cSubject1, 0), cImageID1, cRunnerRunc, 5002, "4", 50));
 
     // Expected run status
-    testData->mExpectedRunStatus.PushBack(CreateInstanceStatus({cService3, cSubject1, 0}, cNodeIDLocalSM, cRunnerRunc));
-    testData->mExpectedRunStatus.PushBack(CreateInstanceStatus({cService1, cSubject1, 0}, cNodeIDLocalSM, cRunnerRunc));
-    testData->mExpectedRunStatus.PushBack(CreateInstanceStatus({cService2, cSubject1, 0}, cNodeIDLocalSM, cRunnerRunc));
+    testData->mExpectedRunStatus.PushBack(
+        CreateInstanceStatus({cService3, cSubject1, 0, UpdateItemTypeEnum::eService}, cNodeIDLocalSM, cRunnerRunc));
+    testData->mExpectedRunStatus.PushBack(
+        CreateInstanceStatus({cService1, cSubject1, 0, UpdateItemTypeEnum::eService}, cNodeIDLocalSM, cRunnerRunc));
+    testData->mExpectedRunStatus.PushBack(
+        CreateInstanceStatus({cService2, cSubject1, 0, UpdateItemTypeEnum::eService}, cNodeIDLocalSM, cRunnerRunc));
 
     testData->mExpectedRunRequests.clear();
     testData->mExpectedRunStatus.Clear();
 
     // Monitoring data
     CreateNodeMonitoring(testData->mMonitoring[cNodeIDLocalSM], cNodeIDLocalSM, 1000,
-        {CreateInstanceMonitoring(InstanceIdent {cService1, cSubject1, 0}, 500),
-            CreateInstanceMonitoring(InstanceIdent {cService2, cSubject1, 0}, 500)});
+        {CreateInstanceMonitoring(InstanceIdent {cService1, cSubject1, 0, UpdateItemTypeEnum::eService}, 500),
+            CreateInstanceMonitoring(InstanceIdent {cService2, cSubject1, 0, UpdateItemTypeEnum::eService}, 500)});
 
     return testData;
 }

--- a/src/core/cm/launcher/tests/stubs/imagestorestub.hpp
+++ b/src/core/cm/launcher/tests/stubs/imagestorestub.hpp
@@ -12,8 +12,8 @@
 #include <string>
 #include <vector>
 
-#include <core/cm/imagemanager/itf/blobinfoprovider.hpp>
 #include <core/cm/imagemanager/itf/iteminfoprovider.hpp>
+#include <core/common/blobinfoprovider/itf/blobinfoprovider.hpp>
 #include <core/common/ocispec/itf/ocispec.hpp>
 
 namespace aos::cm::imagemanager {
@@ -22,7 +22,7 @@ namespace aos::cm::imagemanager {
  * Test helper that emulates OCI images.
  * Provides ItemInfoProvider, BlobInfoProvider, and OCISpec interfaces.
  */
-class ImageStoreStub : public ItemInfoProviderItf, public BlobInfoProviderItf, public oci::OCISpecItf {
+class ImageStoreStub : public ItemInfoProviderItf, public blobinfoprovider::ProviderItf, public oci::OCISpecItf {
 public:
     void Init()
     {
@@ -110,7 +110,7 @@ public:
     //
     // imagemanager::BlobInfoProviderItf
     //
-    Error GetBlobsInfo(const Array<StaticString<oci::cDigestLen>>&, Array<BlobInfo>&) override
+    Error GetBlobsInfos(const Array<StaticString<oci::cDigestLen>>&, Array<BlobInfo>&) override
     {
         return ErrorEnum::eNone;
     }


### PR DESCRIPTION
This patch fixes the next compilation issues:
- aplies blob info provider interface changes;
- adds update item type to instance ident constructor calls.