### PR TITLE
sm: launcher: fix on instances statuses deadlock

### DIFF
--- a/src/core/sm/launcher/launcher.hpp
+++ b/src/core/sm/launcher/launcher.hpp
@@ -186,6 +186,7 @@ private:
     Thread<cThreadTaskSize>                                               mRebootThread;
     ThreadPool<cMaxNumConcurrentItems, cMaxNumInstances, cThreadTaskSize> mLaunchPool;
     mutable Mutex                                                         mMutex;
+    Mutex                                                                 mSubscribersMutex;
     mutable ConditionalVariable                                           mCondVar;
     StaticArray<InstanceData, cMaxNumInstances>                           mInstances;
     StaticMap<RuntimeItf*, StaticString<cIDLen>, cMaxNumNodeRuntimes>     mRuntimes;


### PR DESCRIPTION
Monitoring module calls back into Launcher to obtain instance monitoring parameters, causing a deadlock. This patch moves notifying subscribers outside of the lock.