### PR TITLE
cm: launcher: do not fail activating components

### DIFF
--- a/src/core/cm/launcher/launcher.cpp
+++ b/src/core/cm/launcher/launcher.cpp
@@ -316,7 +316,8 @@ void Launcher::UpdateInstanceStatuses()
 void Launcher::FailActivatingInstances()
 {
     for (auto& instance : mInstanceManager.GetActiveInstances()) {
-        if (instance->GetStatus().mState == aos::InstanceStateEnum::eActivating) {
+        if (instance->GetStatus().mState == aos::InstanceStateEnum::eActivating
+            && instance->GetStatus().mType != UpdateItemTypeEnum::eComponent) {
             // Keep node ID, because instance still scheduled, but node didn't send activating status.
             instance->SetError(AOS_ERROR_WRAP(ErrorEnum::eTimeout), false);
         }

--- a/src/core/cm/launcher/tests/launcher.cpp
+++ b/src/core/cm/launcher/tests/launcher.cpp
@@ -807,7 +807,7 @@ TEST_F(CMLauncherTest, Components)
 
     expectedRunStatus->PushBack(
         CreateInstanceStatus(CreateInstanceIdent(cComponent1, cSubject1, 0, UpdateItemTypeEnum::eComponent),
-            cNodeIDRemoteSM1, cRunnerRootfs));
+            cNodeIDRemoteSM1, cRunnerRootfs, aos::InstanceStateEnum::eActivating, ErrorEnum::eNone));
 
     Array<InstanceStatus> componentStatuses(expectedRunStatus->begin(), expectedRunStatus->Size());
 


### PR DESCRIPTION
Some components (rootfs and boot for example) are activated only after the system is rebooted. So, it's acceptable that they are not activated right after installation.