### PR TITLE
cm: monitoring: omit duplicate states in instance status

### DIFF
--- a/src/core/cm/monitoring/monitoring.cpp
+++ b/src/core/cm/monitoring/monitoring.cpp
@@ -177,6 +177,10 @@ void Monitoring::OnInstancesStatusesChanged(const Array<InstanceStatus>& statuse
             it->mNodeID                      = status.mNodeID;
         }
 
+        if (!it->mStates.IsEmpty() && it->mStates.Back().mState == status.mState) {
+            continue;
+        }
+
         if (it->mStates.IsFull()) {
             it->mStates.Erase(it->mStates.begin());
         }

--- a/src/core/cm/monitoring/tests/monitoring.cpp
+++ b/src/core/cm/monitoring/tests/monitoring.cpp
@@ -277,6 +277,7 @@ TEST_F(CMMonitoring, OnInstancesStatusesChanged)
 
     std::array statuses = {
         CreateInstanceStatus("node1", ident0, InstanceStateEnum::eActivating),
+        CreateInstanceStatus("node1", ident0, InstanceStateEnum::eActivating),
         CreateInstanceStatus("node1", ident0, InstanceStateEnum::eActive),
         CreateInstanceStatus("node1", ident0, InstanceStateEnum::eInactive),
         CreateInstanceStatus("node2", ident0, InstanceStateEnum::eActivating),


### PR DESCRIPTION
This patch ensures that duplicate states are not added if the new state is the same as the last one.