### PR TITLE
sm: launcher: update component status handling

### DIFF
--- a/src/core/sm/launcher/launcher.cpp
+++ b/src/core/sm/launcher/launcher.cpp
@@ -151,7 +151,7 @@ Error Launcher::OnInstancesStatusesReceived(const Array<InstanceStatus>& statuse
                       << Log::Field("runtimeID", status.mRuntimeID) << Log::Field("state", status.mState)
                       << Log::Field(status.mError);
 
-            if (auto storeErr = StoreInstalledComponent(status); err.IsNone() && !storeErr.IsNone()) {
+            if (auto storeErr = HandleComponentStatus(status); err.IsNone() && !storeErr.IsNone()) {
                 err = AOS_ERROR_WRAP(storeErr);
             }
         }
@@ -343,10 +343,14 @@ void Launcher::RunRebootThread()
     }
 }
 
-Error Launcher::StoreInstalledComponent(const aos::InstanceStatus& status)
+Error Launcher::HandleComponentStatus(const aos::InstanceStatus& status)
 {
-    if (!IsPreinstalledInstance(status)) {
+    if (status.mType != UpdateItemTypeEnum::eComponent) {
         return ErrorEnum::eNone;
+    }
+
+    if (status.mState == InstanceStateEnum::eInactive) {
+        return RemoveInstanceData(status);
     }
 
     if (mInstances.ContainsIf([&status](const auto& instance) {
@@ -790,9 +794,8 @@ RetWithError<Launcher::InstanceData*> Launcher::AddInstanceData(const InstanceIn
 
 Error Launcher::RemoveInstanceData(const InstanceIdent& instanceIdent)
 {
-    LockGuard lock {mMutex};
-
     LOG_DBG() << "Remove instance data" << Log::Field("instance", instanceIdent);
+
     if (auto err = mStorage->RemoveInstanceInfo(instanceIdent); !err.IsNone()) {
         LOG_ERR() << "Remove instance info from storage failed" << Log::Field("instance", instanceIdent)
                   << Log::Field(AOS_ERROR_WRAP(err));
@@ -810,6 +813,8 @@ Error Launcher::RemoveInstanceData(const InstanceIdent& instanceIdent)
 
 void Launcher::RemoveInstancesData(const Array<InstanceIdent>& instances)
 {
+    LockGuard lock {mMutex};
+
     for (const auto& instanceIdent : instances) {
         auto instanceData = FindInstanceData(instanceIdent);
         if (!instanceData) {

--- a/src/core/sm/launcher/launcher.hpp
+++ b/src/core/sm/launcher/launcher.hpp
@@ -160,7 +160,7 @@ private:
                 + sizeof(StaticArray<imagemanager::UpdateItemStatus, cMaxNumUpdateItems>));
 
     void  RunRebootThread();
-    Error StoreInstalledComponent(const aos::InstanceStatus& status);
+    Error HandleComponentStatus(const aos::InstanceStatus& status);
     void  UpdateInstancesImpl(Array<InstanceIdent>& stopInstances, const Array<InstanceInfo>& startInstances);
     void  StopInstances(const Array<InstanceIdent>& stopInstances);
     Error StopInstance(InstanceData& instanceData);

--- a/src/core/sm/launcher/tests/launcher.cpp
+++ b/src/core/sm/launcher/tests/launcher.cpp
@@ -204,15 +204,15 @@ TEST_F(LauncherTest, NoStoredInstancesOnModuleStart)
 TEST_F(LauncherTest, SendActiveComponentNodeInstancesStatusOnModuleStart)
 {
     const std::vector cRuntime0Components = {
-        CreateInstanceStatus(CreateInstanceInfo("item0", 0, "1.0.0", "runtime0"), InstanceStateEnum::eActive,
+        CreateInstanceStatus(CreateInstanceInfo("item0", 0, "1.0.1", "runtime0"), InstanceStateEnum::eActive,
             UpdateItemTypeEnum::eComponent),
-        CreateInstanceStatus(CreateInstanceInfo("item1", 1, "1.0.0", "runtime0"), InstanceStateEnum::eInactive,
+        CreateInstanceStatus(CreateInstanceInfo("item1", 0, "1.0.0", "runtime0"), InstanceStateEnum::eInactive,
             UpdateItemTypeEnum::eComponent, true),
         CreateInstanceStatus(CreateInstanceInfo("item2", 2, "1.0.0", "runtime0"), InstanceStateEnum::eActive,
             UpdateItemTypeEnum::eService),
     };
 
-    const auto cPreinstalledComponent = static_cast<const InstanceIdent&>(cRuntime0Components[1]);
+    const auto cActiveComponent = static_cast<const InstanceIdent&>(cRuntime0Components[0]);
 
     EXPECT_CALL(mRuntime0, Start).WillOnce(Invoke([&]() {
         mLauncher.OnInstancesStatusesReceived(
@@ -222,9 +222,9 @@ TEST_F(LauncherTest, SendActiveComponentNodeInstancesStatusOnModuleStart)
     }));
 
     EXPECT_CALL(mRuntime0, StartInstance).WillOnce(Invoke([&](const InstanceInfo& info, InstanceStatus& status) {
-        EXPECT_EQ(static_cast<const InstanceIdent&>(info), cPreinstalledComponent);
+        EXPECT_EQ(static_cast<const InstanceIdent&>(info), cActiveComponent);
 
-        status = cRuntime0Components[1];
+        status = cRuntime0Components[0];
 
         return ErrorEnum::eNone;
     }));
@@ -239,9 +239,9 @@ TEST_F(LauncherTest, SendActiveComponentNodeInstancesStatusOnModuleStart)
     ASSERT_TRUE(err.IsNone()) << tests::utils::ErrorToStr(err);
 
     ASSERT_EQ(mReceivedStatuses.Size(), 1);
-    EXPECT_EQ(mReceivedStatuses[0], cRuntime0Components[1]);
+    EXPECT_EQ(mReceivedStatuses[0], cRuntime0Components[0]);
 
-    EXPECT_CALL(mRuntime0, StopInstance(cPreinstalledComponent, _)).Times(0);
+    EXPECT_CALL(mRuntime0, StopInstance(cActiveComponent, _)).Times(0);
 
     err = mLauncher.Stop();
     ASSERT_TRUE(err.IsNone()) << tests::utils::ErrorToStr(err);
@@ -250,7 +250,7 @@ TEST_F(LauncherTest, SendActiveComponentNodeInstancesStatusOnModuleStart)
 TEST_F(LauncherTest, DoNotSendUpdateInstancesStatusesBeforeModuleStart)
 {
     const std::vector cRuntime0Components = {
-        CreateInstanceStatus(CreateInstanceInfo("item1", 1, "1.0.0", "runtime0"), InstanceStateEnum::eInactive,
+        CreateInstanceStatus(CreateInstanceInfo("item1", 1, "1.0.0", "runtime0"), InstanceStateEnum::eActive,
             UpdateItemTypeEnum::eComponent, true),
     };
 


### PR DESCRIPTION
This patch updates the component status handling to remove all info regarding an inactive components (this status is set once rootfs update is completed, for example).