### PR TITLE
build: add cmake configure step to linting

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -1,0 +1,44 @@
+name: Build (Release)
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+      - feature*
+      - release*
+
+  pull_request:
+    types:
+      - edited
+      - opened
+      - reopened
+      - synchronize
+
+    branches:
+      - main
+      - develop
+      - feature*
+      - release*
+
+jobs:
+  build-release:
+    name: Build (Release)
+    runs-on: ubuntu-22.04
+    permissions: read-all
+    container:
+      image: ghcr.io/aosedge/aos-core-build:latest
+      options: "--entrypoint /usr/bin/bash"
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ github.token }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Build
+        run: |
+          ./build.sh build --build-type Release

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -1,4 +1,4 @@
-name: Build and test
+name: Build (Debug) and test
 
 on:
   push:
@@ -36,22 +36,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
           fetch-depth: 0
 
-      - name: Static analysis
-        run: |
-          ./build.sh lint
-
       - name: Install build wrapper
-        uses: SonarSource/sonarqube-scan-action/install-build-wrapper@v6
-
-      - name: Build (Release)
-        run: |
-          ./build.sh build --build-type Release
+        uses: SonarSource/sonarqube-scan-action/install-build-wrapper@v7
 
       - name: Build (Debug)
         run: |
@@ -62,14 +54,14 @@ jobs:
           ./build.sh coverage
 
       - name: Upload codecov report
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./build/coverage.total
 
       - name: SonarQube analysis (on push)
         if: github.event_name == 'push'
-        uses: SonarSource/sonarqube-scan-action@v6
+        uses: SonarSource/sonarqube-scan-action@v7
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
@@ -80,7 +72,7 @@ jobs:
 
       - name: SonarQube analysis (on pull request)
         if: github.event_name == 'pull_request_target'
-        uses: SonarSource/sonarqube-scan-action@v6
+        uses: SonarSource/sonarqube-scan-action@v7
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-format.yaml
+++ b/.github/workflows/check-format.yaml
@@ -18,7 +18,7 @@ jobs:
     name: Formatting Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to github container registry
         uses: docker/login-action@v3

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,44 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+      - feature*
+      - release*
+
+  pull_request:
+    types:
+      - edited
+      - opened
+      - reopened
+      - synchronize
+
+    branches:
+      - main
+      - develop
+      - feature*
+      - release*
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-22.04
+    permissions: read-all
+    container:
+      image: ghcr.io/aosedge/aos-core-build:latest
+      options: "--entrypoint /usr/bin/bash"
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ github.token }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Static analysis
+        run: |
+          ./build.sh lint

--- a/build.sh
+++ b/build.sh
@@ -55,7 +55,9 @@ conan_setup() {
     conan install ./conan/ --output-folder build --settings=build_type="$ARG_BUILD_TYPE" --build=missing
 }
 
-build_project() {
+cmake_configure() {
+    conan_setup
+
     print_next_step "Run cmake configure"
 
     cmake -S . -B build \
@@ -68,6 +70,10 @@ build_project() {
         -DWITH_COVERAGE=ON \
         -DWITH_MBEDTLS=ON \
         -DWITH_OPENSSL=ON
+}
+
+build_project() {
+    cmake_configure
 
     if [ "$ARG_CI_FLAG" == "true" ]; then
         print_next_step "Run build-wrapper and build (CI mode)"
@@ -118,7 +124,6 @@ build_target() {
         clean_build
     fi
 
-    conan_setup
     build_project
 }
 
@@ -141,6 +146,8 @@ run_coverage() {
 }
 
 run_lint() {
+    cmake_configure
+
     print_next_step "Run static analysis (cppcheck)"
 
     cppcheck --enable=all --inline-suppr --std=c++17 --error-exitcode=1 \


### PR DESCRIPTION
compile_commands.json is generated during cmake configure step, so it should be run before cppcheck.
This patch makes it possible to execute lint step without building the project, which fixes the issue with linting on CI.