### PR TITLE
sm: launcher: rename update instances to run instances

### DIFF
--- a/src/core/sm/launcher/itf/launcher.hpp
+++ b/src/core/sm/launcher/itf/launcher.hpp
@@ -27,14 +27,12 @@ public:
     virtual ~LauncherItf() = default;
 
     /**
-     * Update running instances.
+     * Runs instances.
      *
-     * @param stopInstances instances to stop.
-     * @param startInstances instances to start.
+     * @param instances instances to run.
      * @return Error.
      */
-    virtual Error UpdateInstances(const Array<InstanceIdent>& stopInstances, const Array<InstanceInfo>& startInstances)
-        = 0;
+    virtual Error RunInstances(const Array<InstanceInfo>& instances) = 0;
 };
 
 /** @}*/

--- a/src/core/sm/launcher/launcher.cpp
+++ b/src/core/sm/launcher/launcher.cpp
@@ -77,7 +77,7 @@ Error Launcher::Start()
 
     lock.Unlock();
 
-    if (auto err = UpdateInstances({}, *storedInstances); !err.IsNone()) {
+    if (auto err = RunInstances(*storedInstances); !err.IsNone()) {
         return AOS_ERROR_WRAP(err);
     }
 
@@ -131,8 +131,10 @@ Error Launcher::Stop()
     return stopErr;
 }
 
-Error Launcher::UpdateInstances(const Array<InstanceIdent>& stopInstances, const Array<InstanceInfo>& startInstances)
+Error Launcher::RunInstances(const Array<InstanceInfo>& instances)
 {
+    LOG_DBG() << "Run instances" << Log::Field("count", instances.Size());
+
     if (auto err = StartLaunch(); !err.IsNone()) {
         return AOS_ERROR_WRAP(err);
     }
@@ -140,16 +142,32 @@ Error Launcher::UpdateInstances(const Array<InstanceIdent>& stopInstances, const
     // Wait in case previous request is not yet finished
     mThread.Join();
 
-    auto stop  = MakeShared<StaticArray<InstanceIdent, cMaxNumInstances>>(&mAllocator, stopInstances);
-    auto start = MakeShared<InstanceInfoArray>(&mAllocator, startInstances);
+    mStopInstances.Clear();
+    mStartInstances.Clear();
 
-    if (auto err = mThread.Run([this, stop, start](void*) {
-            UpdateInstancesImpl(*stop, *start);
+    auto err = mStartInstances.Assign(instances);
+    if (!err.IsNone()) {
+        return AOS_ERROR_WRAP(err);
+    }
+
+    SortStartInstances();
+
+    auto clear = DeferRelease(&err, [this](const Error* err) {
+        if (!err->IsNone()) {
             FinishLaunch();
-        });
-        !err.IsNone()) {
-        FinishLaunch();
+        }
+    });
 
+    err = SetStopInstances();
+    if (!err.IsNone()) {
+        return AOS_ERROR_WRAP(err);
+    }
+
+    err = mThread.Run([this](void*) {
+        RunInstancesImpl();
+        FinishLaunch();
+    });
+    if (!err.IsNone()) {
         return AOS_ERROR_WRAP(err);
     }
 
@@ -546,10 +564,27 @@ Error Launcher::HandleComponentStatus(const aos::InstanceStatus& status)
     return ErrorEnum::eNone;
 }
 
-void Launcher::UpdateInstancesImpl(Array<InstanceIdent>& stopInstances, const Array<InstanceInfo>& startInstances)
+void Launcher::SortStartInstances()
 {
-    LOG_INF() << "Update instances" << Log::Field("stopCount", stopInstances.Size())
-              << Log::Field("startCount", startInstances.Size());
+    auto sortTmpValue = MakeUnique<InstanceInfo>(&mAllocator);
+
+    // Sort instances by priority and instance ID to have deterministic order
+    // of start/stop in case of same priority.
+    mStartInstances.Sort(
+        [](const InstanceInfo& a, const InstanceInfo& b) {
+            if (a.mPriority != b.mPriority) {
+                return a.mPriority > b.mPriority;
+            }
+
+            return static_cast<const InstanceIdent&>(a) < static_cast<const InstanceIdent&>(b);
+        },
+        *sortTmpValue);
+}
+
+void Launcher::RunInstancesImpl()
+{
+    LOG_INF() << "Update instances" << Log::Field("stopCount", mStopInstances.Size())
+              << Log::Field("startCount", mStartInstances.Size());
 
     auto sendStatus = DeferRelease(&mInstances, [this](Array<InstanceData>*) {
         LockGuard lock {mMutex};
@@ -569,34 +604,30 @@ void Launcher::UpdateInstancesImpl(Array<InstanceIdent>& stopInstances, const Ar
         return;
     }
 
-    if (auto err = AppendInstancesWithModifiedParams(startInstances, stopInstances); !err.IsNone()) {
-        LOG_ERR() << "Failed to append instances with modified params to stop list" << Log::Field(AOS_ERROR_WRAP(err));
-    }
-
     auto removeItems = MakeUnique<StaticArray<UpdateItemInfo, cMaxNumUpdateItems>>(&mAllocator);
 
     if (!mFirstStart) {
-        GetRemoveUpdateItems(stopInstances, startInstances, *removeItems);
+        GetRemoveUpdateItems(mStopInstances, mStartInstances, *removeItems);
     }
 
-    StopInstances(stopInstances);
+    StopInstances(mStopInstances);
 
     if (auto err = mLaunchPool.Wait(); !err.IsNone()) {
         LOG_ERR() << "Thread pool wait failed" << Log::Field(AOS_ERROR_WRAP(err));
     }
 
-    RemoveInstancesData(stopInstances);
+    RemoveInstancesData(mStopInstances);
 
     if (!mFirstStart) {
         RemoveUpdateItems(*removeItems);
-        InstallUpdateItems(startInstances);
+        InstallUpdateItems(mStartInstances);
 
         if (auto err = mLaunchPool.Wait(); !err.IsNone()) {
             LOG_ERR() << "Thread pool wait failed" << Log::Field(AOS_ERROR_WRAP(err));
         }
     }
 
-    StartInstances(startInstances);
+    StartInstances(mStartInstances);
 
     if (auto err = mLaunchPool.Wait(); !err.IsNone()) {
         LOG_ERR() << "Thread pool wait failed" << Log::Field(AOS_ERROR_WRAP(err));
@@ -605,6 +636,32 @@ void Launcher::UpdateInstancesImpl(Array<InstanceIdent>& stopInstances, const Ar
     if (auto err = mLaunchPool.Shutdown(); !err.IsNone()) {
         LOG_ERR() << "Thread pool shutdown failed" << Log::Field(AOS_ERROR_WRAP(err));
     }
+}
+
+Error Launcher::SetStopInstances()
+{
+    mStopInstances.Clear();
+
+    for (const auto& instance : mInstances) {
+        if (mStartInstances.ContainsIf([&instance](const auto& startInstance) {
+                return static_cast<const InstanceIdent&>(startInstance)
+                    == static_cast<const InstanceIdent&>(instance.mInfo)
+                    && (startInstance.mVersion == instance.mInfo.mVersion
+                        || startInstance.mManifestDigest == instance.mInfo.mManifestDigest);
+            })) {
+            continue;
+        }
+
+        if (auto err = mStopInstances.EmplaceBack(instance.mStatus); !err.IsNone()) {
+            return AOS_ERROR_WRAP(err);
+        }
+    }
+
+    if (auto err = AppendInstancesWithModifiedParams(mStartInstances, mStopInstances); !err.IsNone()) {
+        return AOS_ERROR_WRAP(err);
+    }
+
+    return ErrorEnum::eNone;
 }
 
 void Launcher::StopInstances(const Array<InstanceIdent>& stopInstances)
@@ -766,6 +823,8 @@ Error Launcher::AppendInstancesWithModifiedParams(
 Error Launcher::StartLaunch()
 {
     LockGuard lock {mMutex};
+
+    LOG_DBG() << "Start launch" << Log::Field("launchInProgress", mLaunchInProgress);
 
     if (mLaunchInProgress) {
         return AOS_ERROR_WRAP(ErrorEnum::eWrongState);

--- a/src/core/sm/launcher/launcher.hpp
+++ b/src/core/sm/launcher/launcher.hpp
@@ -70,14 +70,12 @@ public:
     Error Stop();
 
     /**
-     * Update running instances.
+     * Runs instances.
      *
-     * @param stopInstances instances to stop.
-     * @param startInstances instances to start.
+     * @param instances instances to run.
      * @return Error.
      */
-    Error UpdateInstances(
-        const Array<InstanceIdent>& stopInstances, const Array<InstanceInfo>& startInstances) override;
+    Error RunInstances(const Array<InstanceInfo>& instances) override;
 
     /**
      * Receives instances statuses.
@@ -173,7 +171,9 @@ private:
     void  RunRebootThread();
     void  HandleOfflineTTLs();
     Error HandleComponentStatus(const aos::InstanceStatus& status);
-    void  UpdateInstancesImpl(Array<InstanceIdent>& stopInstances, const Array<InstanceInfo>& startInstances);
+    void  SortStartInstances();
+    void  RunInstancesImpl();
+    Error SetStopInstances();
     void  StopInstances(const Array<InstanceIdent>& stopInstances);
     Error StopInstance(InstanceData& instanceData);
     void  StopAllInstances();
@@ -227,6 +227,8 @@ private:
     bool                                                                  mIsRunning {};
     bool                                                                  mFirstStart {true};
     Optional<Time>                                                        mOfflineTime {};
+    StaticArray<InstanceIdent, cMaxNumInstances>                          mStopInstances;
+    InstanceInfoArray                                                     mStartInstances;
 };
 
 } // namespace aos::sm::launcher

--- a/src/core/sm/launcher/tests/launcher.cpp
+++ b/src/core/sm/launcher/tests/launcher.cpp
@@ -279,7 +279,7 @@ TEST_F(LauncherTest, SendActiveComponentNodeInstancesStatusOnModuleStart)
     ASSERT_TRUE(err.IsNone()) << tests::utils::ErrorToStr(err);
 }
 
-TEST_F(LauncherTest, DoNotSendUpdateInstancesStatusesBeforeModuleStart)
+TEST_F(LauncherTest, DoNotSendRunInstancesStatusesBeforeModuleStart)
 {
     const std::vector cRuntime0Components = {
         CreateInstanceStatus(CreateInstanceInfo("item1", 1, "1.0.0", "runtime0"), InstanceStateEnum::eActive,
@@ -459,7 +459,7 @@ TEST_F(LauncherTest, StopInstancesWithExpiredOfflineTTL)
     ASSERT_TRUE(err.IsNone()) << tests::utils::ErrorToStr(err);
 }
 
-TEST_F(LauncherTest, UpdateInstances)
+TEST_F(LauncherTest, RunInstances)
 {
     const std::vector cStoredInfos = {
         CreateInstanceInfo("item0", 0, "1.0.0", "runtime0"),
@@ -468,8 +468,7 @@ TEST_F(LauncherTest, UpdateInstances)
         CreateInstanceInfo("item1", 1, "1.0.0", "runtime0"),
         CreateInstanceInfo("item2", 2, "1.0.0", "runtime1"),
     };
-    const Array<InstanceInfo>  cStartInstances(&cStartInstanceInfos.front(), cStartInstanceInfos.size());
-    const Array<InstanceIdent> cStopInstances(&static_cast<const InstanceIdent&>(cStoredInfos.front()), 1);
+    const Array<InstanceInfo> cStartInstances(&cStartInstanceInfos.front(), cStartInstanceInfos.size());
 
     mStorage.Init(cStoredInfos);
 
@@ -530,7 +529,7 @@ TEST_F(LauncherTest, UpdateInstances)
             return ErrorEnum::eNone;
         }));
 
-    err = mLauncher.UpdateInstances(cStopInstances, cStartInstances);
+    err = mLauncher.RunInstances(cStartInstances);
     ASSERT_TRUE(err.IsNone()) << tests::utils::ErrorToStr(err);
 
     err = mSender.WaitStatuses(mReceivedStatuses, cWaitTimeout);
@@ -567,7 +566,7 @@ TEST_F(LauncherTest, UpdateInstances)
     ASSERT_TRUE(err.IsNone()) << tests::utils::ErrorToStr(err);
 }
 
-TEST_F(LauncherTest, UpdateInstancesRestartsInstancesWithModifiedParams)
+TEST_F(LauncherTest, RunInstancesRestartsInstancesWithModifiedParams)
 {
     const std::vector cStoredInfos = {
         CreateInstanceInfo("item0", 0, "1.0.0", "runtime0"),
@@ -617,7 +616,7 @@ TEST_F(LauncherTest, UpdateInstancesRestartsInstancesWithModifiedParams)
         return ErrorEnum::eNone;
     }));
 
-    err = mLauncher.UpdateInstances({}, cStartInstances);
+    err = mLauncher.RunInstances(cStartInstances);
     ASSERT_TRUE(err.IsNone()) << tests::utils::ErrorToStr(err);
 
     err = mSender.WaitStatuses(mReceivedStatuses, cWaitTimeout);
@@ -646,7 +645,7 @@ TEST_F(LauncherTest, UpdateInstancesRestartsInstancesWithModifiedParams)
     ASSERT_TRUE(err.IsNone()) << tests::utils::ErrorToStr(err);
 }
 
-TEST_F(LauncherTest, ParallelUpdateInstancesDoesNotInterfere)
+TEST_F(LauncherTest, ParallelRunInstancesDoesNotInterfere)
 {
     const std::vector cStartInstanceInfos = {
         CreateInstanceInfo("item0", 0, "1.0.0", "runtime0"),
@@ -678,10 +677,10 @@ TEST_F(LauncherTest, ParallelUpdateInstancesDoesNotInterfere)
             return ErrorEnum::eNone;
         }));
 
-    err = mLauncher.UpdateInstances({}, cStartFirstInstance);
+    err = mLauncher.RunInstances(cStartFirstInstance);
     ASSERT_TRUE(err.IsNone()) << tests::utils::ErrorToStr(err);
 
-    err = mLauncher.UpdateInstances({}, cStartInstances);
+    err = mLauncher.RunInstances(cStartInstances);
     ASSERT_TRUE(err.Is(ErrorEnum::eWrongState)) << tests::utils::ErrorToStr(err);
 
     launchPromise.set_value();
@@ -752,7 +751,7 @@ TEST_F(LauncherTest, GetInstancesStatuses)
     err = mLauncher.GetInstancesStatuses(mReceivedStatuses);
     ASSERT_TRUE(err.IsNone()) << tests::utils::ErrorToStr(err);
 
-    err = mLauncher.UpdateInstances({}, cStartInstances);
+    err = mLauncher.RunInstances(cStartInstances);
     ASSERT_TRUE(err.IsNone()) << tests::utils::ErrorToStr(err);
 
     err = mSender.WaitStatuses(mReceivedStatuses, cWaitTimeout);
@@ -809,7 +808,7 @@ TEST_F(LauncherTest, GetInstanceMonitoringParams)
     err = mLauncher.GetInstancesStatuses(mReceivedStatuses);
     ASSERT_TRUE(err.IsNone()) << tests::utils::ErrorToStr(err);
 
-    err = mLauncher.UpdateInstances({}, cStartInstances);
+    err = mLauncher.RunInstances(cStartInstances);
     ASSERT_TRUE(err.IsNone()) << tests::utils::ErrorToStr(err);
 
     err = mSender.WaitStatuses(mReceivedStatuses, cWaitTimeout);
@@ -865,7 +864,7 @@ TEST_F(LauncherTest, GetInstanceMonitoringData)
             return ErrorEnum::eNone;
         }));
 
-    err = mLauncher.UpdateInstances({}, cStartInstances);
+    err = mLauncher.RunInstances(cStartInstances);
     ASSERT_TRUE(err.IsNone()) << tests::utils::ErrorToStr(err);
 
     err = mSender.WaitStatuses(mReceivedStatuses, cWaitTimeout);

--- a/src/core/sm/tests/mocks/launchermock.hpp
+++ b/src/core/sm/tests/mocks/launchermock.hpp
@@ -19,8 +19,7 @@ namespace aos::sm::launcher {
  */
 class LauncherMock : public LauncherItf {
 public:
-    MOCK_METHOD(Error, UpdateInstances,
-        (const Array<InstanceIdent>& stopInstances, const Array<InstanceInfo>& startInstances), (override));
+    MOCK_METHOD(Error, RunInstances, (const Array<InstanceInfo>& instances), (override));
 };
 
 } // namespace aos::sm::launcher


### PR DESCRIPTION
This patch updated launcher interface to handle
run instances instead of update instances:
- a list of desired run instances is passed to the launcher instead stop and start instances lists;
- the launcher is responsible for stopping and starting instances based on the provided list of desired run instances;
- instances are started based on the desired run instances priorities.