### PR TITLE
sm: launcher: rename SendUpdateInstancesStatuses

### DIFF
--- a/src/core/sm/launcher/itf/sender.hpp
+++ b/src/core/sm/launcher/itf/sender.hpp
@@ -34,12 +34,12 @@ public:
     virtual Error SendNodeInstancesStatuses(const Array<aos::InstanceStatus>& statuses) = 0;
 
     /**
-     * Sends update instances statuses.
+     * Sends instance status.
      *
-     * @param statuses instances statuses.
+     * @param status instance status.
      * @return Error.
      */
-    virtual Error SendUpdateInstancesStatuses(const Array<aos::InstanceStatus>& statuses) = 0;
+    virtual Error SendInstanceStatus(const aos::InstanceStatus& status) = 0;
 };
 
 /** @}*/

--- a/src/core/sm/launcher/launcher.cpp
+++ b/src/core/sm/launcher/launcher.cpp
@@ -191,11 +191,11 @@ Error Launcher::OnInstancesStatusesReceived(const Array<InstanceStatus>& statuse
             if (auto storeErr = HandleComponentStatus(status); err.IsNone() && !storeErr.IsNone()) {
                 err = AOS_ERROR_WRAP(storeErr);
             }
-        }
 
-        if (!mFirstStart) {
-            if (auto sendErr = mSender->SendUpdateInstancesStatuses(statuses); err.IsNone() && !sendErr.IsNone()) {
-                err = AOS_ERROR_WRAP(sendErr);
+            if (!mFirstStart) {
+                if (auto sendErr = mSender->SendInstanceStatus(status); err.IsNone() && !sendErr.IsNone()) {
+                    err = AOS_ERROR_WRAP(sendErr);
+                }
             }
         }
     }

--- a/src/core/sm/launcher/launcher.md
+++ b/src/core/sm/launcher/launcher.md
@@ -181,9 +181,9 @@ Marks runtime for reboot. Reboot will be performed after current launch is compl
 
 Sends node instances statuses once update is completed.
 
-### SendUpdateInstancesStatuses
+### SendInstanceStatus
 
-Propagates updated instances statuses received from runtimes.
+Propagates updated instance status received from a runtime.
 
 ## aos::sm::launcher::LauncherItf
 

--- a/src/core/sm/launcher/tests/stubs/senderstub.hpp
+++ b/src/core/sm/launcher/tests/stubs/senderstub.hpp
@@ -24,17 +24,17 @@ public:
     {
         std::lock_guard lock {mMutex};
 
-        mStatusesQueue.push(statuses);
+        mStatusesQueue.emplace(statuses);
         mCondVar.notify_one();
 
         return ErrorEnum::eNone;
     }
 
-    Error SendUpdateInstancesStatuses(const Array<aos::InstanceStatus>& statuses) override
+    Error SendInstanceStatus(const aos::InstanceStatus& status) override
     {
         std::lock_guard lock {mMutex};
 
-        mStatusesQueue.push(statuses);
+        mStatusesQueue.emplace(Array<InstanceStatus> {&status, 1});
         mCondVar.notify_one();
 
         return ErrorEnum::eNone;


### PR DESCRIPTION
This patch renames the SendUpdateInstancesStatuses method to SendInstanceStatus with one instance status.