### PR TITLE
cm: updatemanager: fix dead lock in unit status handling

### DIFF
--- a/src/core/cm/updatemanager/unitstatushandler.cpp
+++ b/src/core/cm/updatemanager/unitstatushandler.cpp
@@ -94,10 +94,14 @@ Error UnitStatusHandler::Stop()
 
 Error UnitStatusHandler::SendFullUnitStatus()
 {
-    LockGuard lock {mMutex};
+    {
+        LockGuard lock {mMutex};
 
-    if (!mCloudConnected) {
-        return ErrorEnum::eNone;
+        if (!mCloudConnected) {
+            return ErrorEnum::eNone;
+        }
+
+        mIsStatusProcessing = true;
     }
 
     LOG_INF() << "Send full unit status";
@@ -128,16 +132,22 @@ Error UnitStatusHandler::SendFullUnitStatus()
         return AOS_ERROR_WRAP(err);
     }
 
-    LogUnitStatus();
+    {
+        LogUnitStatus();
 
-    if (auto err = mSender->SendUnitStatus(mUnitStatus); !err.IsNone()) {
-        return AOS_ERROR_WRAP(err);
+        if (auto err = mSender->SendUnitStatus(mUnitStatus); !err.IsNone()) {
+            return AOS_ERROR_WRAP(err);
+        }
+
+        ClearUnitStatus();
+        ClearUpdateStatuses();
+
+        mTimer.Stop();
+
+        LockGuard lock {mMutex};
+
+        mIsStatusProcessing = false;
     }
-
-    ClearUnitStatus();
-    ClearUpdateStatuses();
-
-    mTimer.Stop();
 
     return ErrorEnum::eNone;
 }
@@ -204,7 +214,7 @@ void UnitStatusHandler::OnNodeInfoChanged(const UnitNodeInfo& info)
               << Log::Field("state", info.mState) << Log::Field("isConnected", info.mIsConnected)
               << Log::Field(nodeError);
 
-    if (!mCloudConnected) {
+    if (!mCloudConnected || mIsStatusProcessing) {
         return;
     }
 
@@ -236,7 +246,7 @@ void UnitStatusHandler::OnItemsStatusesChanged(const Array<UpdateItemStatus>& st
                   << Log::Field(status.mError);
     }
 
-    if (!mCloudConnected) {
+    if (!mCloudConnected || mIsStatusProcessing) {
         return;
     }
 
@@ -277,7 +287,7 @@ void UnitStatusHandler::OnInstancesStatusesChanged(const Array<InstanceStatus>& 
                   << Log::Field("state", status.mState) << Log::Field(status.mError);
     }
 
-    if (!mCloudConnected || statuses.Size() == 0) {
+    if (!mCloudConnected || mIsStatusProcessing || statuses.Size() == 0) {
         return;
     }
 
@@ -330,7 +340,7 @@ void UnitStatusHandler::SubjectsChanged(const Array<StaticString<cIDLen>>& subje
         LOG_INF() << "New subject" << Log::Field("subjectID", subjectID);
     }
 
-    if (!mCloudConnected) {
+    if (!mCloudConnected || mIsStatusProcessing) {
         return;
     }
 
@@ -355,10 +365,14 @@ void UnitStatusHandler::OnConnect()
     {
         LockGuard lock {mMutex};
 
-        mCloudConnected = true;
-    }
+        LOG_DBG() << "Cloud connected";
 
-    LOG_DBG() << "Cloud connected";
+        mCloudConnected = true;
+
+        if (mIsStatusProcessing) {
+            return;
+        }
+    }
 
     if (auto err = SendFullUnitStatus(); !err.IsNone()) {
         LOG_ERR() << "Failed to send full unit status on cloud connect" << Log::Field(err);

--- a/src/core/cm/updatemanager/unitstatushandler.hpp
+++ b/src/core/cm/updatemanager/unitstatushandler.hpp
@@ -135,6 +135,7 @@ private:
     UnitStatus                      mUnitStatus;
     StaticAllocator<cAllocatorSize> mAllocator;
     bool                            mCloudConnected {};
+    bool                            mIsStatusProcessing {};
 
     Timer    mTimer;
     bool     mTimerStarted {};


### PR DESCRIPTION
### Dead lock occurs when we send full unit status and try to retrieve all instances status from launch. And at same time instance status update received. We have circular lock dependency:

SMHandler::ProcessMessages()
 → Launcher::OnInstanceStatusReceived()         ← acquires mUpdateMutex (Lock A)
   → Launcher::UpdateInstanceStatuses()
     → listener->OnInstancesStatusesChanged()   ← UnitStatusHandler
       → LockGuard lock{mMutex}                 ← BLOCKED waiting for Lock B

DesiredStatusHandler::Run()
  → UnitStatusHandler::SendFullUnitStatus()      ← acquires mMutex (Lock B)
    → UnitStatusHandler::SetInstancesStatus()
      → Launcher::GetInstancesStatuses()
        → LockGuard updateLock{mUpdateMutex}     ← BLOCKED waiting for Lock A

Resolve it by adding mIsStatusProcessing flag that checked on status update and call getting all instances statuses and other statuses without lock.