### PR TITLE
cm: updatemanager: increase allocator size

### DIFF
--- a/src/core/cm/updatemanager/desiredstatushandler.hpp
+++ b/src/core/cm/updatemanager/desiredstatushandler.hpp
@@ -67,8 +67,10 @@ public:
 
 private:
     static constexpr auto cAllocatorSize = Max(sizeof(StaticArray<UpdateItemStatus, cMaxNumUpdateItems>),
-        sizeof(StaticArray<launcher::RunInstanceRequest, cMaxNumInstances>)
-            + sizeof(StaticArray<InstanceStatus, cMaxNumInstances>));
+                                               sizeof(StaticArray<launcher::RunInstanceRequest, cMaxNumInstances>)
+                                                   + sizeof(StaticArray<InstanceStatus, cMaxNumInstances>))
+        + Max(sizeof(StaticArray<UpdateItemStatus, cMaxNumUpdateItems>),
+            sizeof(StaticArray<launcher::RunInstanceRequest, cMaxNumInstances>));
 
     void  Run();
     void  LogDesiredStatus(const DesiredStatus& desiredStatus);


### PR DESCRIPTION
IsUpdateItemsRequired and IsUpdateInstancesRequired allocate items and instances statuses. And if we receive new desired status during processing new one we have run out of allocated space.