### PR TITLE
cm: updatemanager: do not process same desired status

### DIFF
--- a/src/core/cm/updatemanager/desiredstatushandler.cpp
+++ b/src/core/cm/updatemanager/desiredstatushandler.cpp
@@ -103,17 +103,23 @@ Error DesiredStatusHandler::ProcessDesiredStatus(const DesiredStatus& desiredSta
 
     LogDesiredStatus(desiredStatus);
 
-    if (!IsUpdateRequired(desiredStatus)) {
-        LOG_INF() << "No update is required";
-
-        return ErrorEnum::eNone;
-    }
-
     if (mUpdateState != UpdateStateEnum::eNone) {
+        if (IsSameUpdate(desiredStatus)) {
+            LOG_DBG() << "No update is required";
+
+            return ErrorEnum::eNone;
+        }
+
         LOG_DBG() << "Cancel current update to process new desired status";
 
         CancelUpdate();
     } else {
+        if (!IsUpdateRequired(desiredStatus)) {
+            LOG_INF() << "No update is required";
+
+            return ErrorEnum::eNone;
+        }
+
         StartUpdate();
     }
 
@@ -503,6 +509,31 @@ bool DesiredStatusHandler::IsUpdateItemsRequired(const DesiredStatus& desiredSta
     }
 
     return false;
+}
+
+bool DesiredStatusHandler::IsSameUpdate(const DesiredStatus& desiredStatus) const
+{
+    if (desiredStatus.mNodes != mPendingDesiredStatus.mNodes) {
+        return false;
+    }
+
+    if (desiredStatus.mUnitConfig != mPendingDesiredStatus.mUnitConfig) {
+        return false;
+    }
+
+    if (desiredStatus.mUpdateItems != mPendingDesiredStatus.mUpdateItems) {
+        return false;
+    }
+
+    if (desiredStatus.mInstances != mPendingDesiredStatus.mInstances) {
+        return false;
+    }
+
+    if (desiredStatus.mSubjects != mPendingDesiredStatus.mSubjects) {
+        return false;
+    }
+
+    return true;
 }
 
 bool DesiredStatusHandler::IsUpdateInstancesRequired(const DesiredStatus& desiredStatus) const

--- a/src/core/cm/updatemanager/desiredstatushandler.hpp
+++ b/src/core/cm/updatemanager/desiredstatushandler.hpp
@@ -81,6 +81,7 @@ private:
     Error FinalizeUpdate();
     void  StartUpdate(UpdateState state = UpdateStateEnum::eDownloading);
     void  CancelUpdate();
+    bool  IsSameUpdate(const DesiredStatus& desiredStatus) const;
     bool  IsUpdateRequired(const DesiredStatus& desiredStatus) const;
     bool  IsUpdateItemsRequired(const DesiredStatus& desiredStatus) const;
     bool  IsUpdateInstancesRequired(const DesiredStatus& desiredStatus) const;

--- a/src/core/cm/updatemanager/tests/updatemanager.cpp
+++ b/src/core/cm/updatemanager/tests/updatemanager.cpp
@@ -909,7 +909,6 @@ TEST_F(UpdateManagerTest, CancelCurrentUpdate)
     EXPECT_CALL(mLauncherMock, RunInstances(*runRequest, _)).Times(1);
     EXPECT_CALL(mImageManagerMock, InstallUpdateItems(desiredStatus->mUpdateItems, _)).Times(1);
     EXPECT_CALL(mImageManagerMock, GetUpdateItemsStatuses(_))
-        .WillOnce(DoAll(SetArgReferee<0>(UpdateItemStatusArray()), Return(ErrorEnum::eNone)))
         .WillOnce(DoAll(SetArgReferee<0>(expectedUnitStatus->mUpdateItems.GetValue()), Return(ErrorEnum::eNone)));
     EXPECT_CALL(mLauncherMock, GetInstancesStatuses(_)).WillOnce(Invoke([&](Array<InstanceStatus>& instances) {
         ConvertInstancesStatuses(expectedUnitStatus->mInstances.GetValue(), instances);


### PR DESCRIPTION
> We should not process desired status if same desired status received when another one is being processed.