### PR TITLE
cm: updatemanager: desiredstatushandler: handle activating components

### DIFF
--- a/src/core/cm/updatemanager/desiredstatushandler.cpp
+++ b/src/core/cm/updatemanager/desiredstatushandler.cpp
@@ -588,7 +588,8 @@ bool DesiredStatusHandler::IsUpdateInstancesRequired(const DesiredStatus& desire
                     return true;
                 }
 
-                if (instanceStatus.mState != InstanceStateEnum::eActive) {
+                if (instanceStatus.mState != InstanceStateEnum::eActive
+                    && instanceStatus.mState != InstanceStateEnum::eActivating) {
                     return true;
                 }
             }


### PR DESCRIPTION
This prevents CM update manager spamming with run request when component is in activating state.