### PR TITLE
cm: updatemanager: add wait instance activating step

### DIFF
--- a/src/core/cm/updatemanager/desiredstatushandler.cpp
+++ b/src/core/cm/updatemanager/desiredstatushandler.cpp
@@ -40,9 +40,15 @@ Error DesiredStatusHandler::Start()
         return ErrorEnum::eWrongState;
     }
 
+    if (auto err = mLauncher->SubscribeListener(*this); !err.IsNone()) {
+        return AOS_ERROR_WRAP(err);
+    }
+
     mIsRunning = true;
 
     if (auto err = mThread.Run([this](void*) { Run(); }); !err.IsNone()) {
+        mIsRunning = false;
+
         return AOS_ERROR_WRAP(err);
     }
 
@@ -141,6 +147,15 @@ Error DesiredStatusHandler::ProcessDesiredStatus(const DesiredStatus& desiredSta
  * Private
  **********************************************************************************************************************/
 
+void DesiredStatusHandler::OnInstancesStatusesChanged(const Array<InstanceStatus>& statuses)
+{
+    (void)statuses;
+
+    LockGuard lock {mMutex};
+
+    mCondVar.NotifyOne();
+}
+
 void DesiredStatusHandler::StartUpdate(UpdateState state)
 {
     SetState(state);
@@ -206,6 +221,12 @@ void DesiredStatusHandler::Run()
 
                 case UpdateStateEnum::eLaunching:
                     stateAction = &DesiredStatusHandler::LaunchInstances;
+                    nextState   = UpdateStateEnum::eWaitingActive;
+
+                    break;
+
+                case UpdateStateEnum::eWaitingActive:
+                    stateAction = &DesiredStatusHandler::WaitInstancesActive;
                     nextState   = UpdateStateEnum::eFinalizing;
 
                     break;
@@ -217,6 +238,10 @@ void DesiredStatusHandler::Run()
                     break;
 
                 default:
+                    break;
+                }
+
+                if (!mIsRunning) {
                     break;
                 }
 
@@ -427,6 +452,39 @@ Error DesiredStatusHandler::LaunchInstances()
             LOG_ERR() << "Failed to launch instance"
                       << Log::Field("item", static_cast<const InstanceIdent&>(instanceStatus))
                       << Log::Field("err", instanceStatus.mError);
+        }
+    }
+
+    return ErrorEnum::eNone;
+}
+
+Error DesiredStatusHandler::WaitInstancesActive()
+{
+    UniqueLock lock {mMutex};
+
+    auto instancesStatuses = MakeUnique<StaticArray<InstanceStatus, cMaxNumInstances>>(&mAllocator);
+
+    while (mIsRunning) {
+        if (auto err = mLauncher->GetInstancesStatuses(*instancesStatuses); !err.IsNone()) {
+            return AOS_ERROR_WRAP(err);
+        }
+
+        auto allActive = true;
+
+        for (const auto& instanceStatus : *instancesStatuses) {
+            if (instanceStatus.mState == InstanceStateEnum::eActivating) {
+                allActive = false;
+
+                break;
+            }
+        }
+
+        if (allActive) {
+            break;
+        }
+
+        if (auto err = mCondVar.Wait(lock, cWaitActiveTimeout); !err.IsNone()) {
+            return AOS_ERROR_WRAP(err);
         }
     }
 

--- a/src/core/cm/updatemanager/desiredstatushandler.hpp
+++ b/src/core/cm/updatemanager/desiredstatushandler.hpp
@@ -26,7 +26,7 @@ namespace aos::cm::updatemanager {
 /**
  * Desired status handler.
  */
-class DesiredStatusHandler {
+class DesiredStatusHandler : private instancestatusprovider::ListenerItf {
 public:
     /**
      * Initializes desired status handler.
@@ -66,11 +66,15 @@ public:
     Error ProcessDesiredStatus(const DesiredStatus& desiredStatus);
 
 private:
-    static constexpr auto cAllocatorSize = Max(sizeof(StaticArray<UpdateItemStatus, cMaxNumUpdateItems>),
-                                               sizeof(StaticArray<launcher::RunInstanceRequest, cMaxNumInstances>)
-                                                   + sizeof(StaticArray<InstanceStatus, cMaxNumInstances>))
+    static constexpr auto cWaitActiveTimeout = Time::cMinutes * 10;
+    static constexpr auto cAllocatorSize     = Max(sizeof(StaticArray<UpdateItemStatus, cMaxNumUpdateItems>),
+                                                   sizeof(StaticArray<launcher::RunInstanceRequest, cMaxNumInstances>)
+                                                       + sizeof(StaticArray<InstanceStatus, cMaxNumInstances>))
         + Max(sizeof(StaticArray<UpdateItemStatus, cMaxNumUpdateItems>),
             sizeof(StaticArray<launcher::RunInstanceRequest, cMaxNumInstances>));
+
+    // instancestatusprovider::ListenerItf implementation
+    void OnInstancesStatusesChanged(const Array<InstanceStatus>& statuses) override;
 
     void  Run();
     void  LogDesiredStatus(const DesiredStatus& desiredStatus);
@@ -78,6 +82,7 @@ private:
     Error DownloadUpdateItems();
     Error InstallDesiredStatus();
     Error LaunchInstances();
+    Error WaitInstancesActive();
     Error FinalizeUpdate();
     void  StartUpdate(UpdateState state = UpdateStateEnum::eDownloading);
     void  CancelUpdate();

--- a/src/core/cm/updatemanager/itf/storage.hpp
+++ b/src/core/cm/updatemanager/itf/storage.hpp
@@ -27,6 +27,7 @@ public:
         ePending,
         eInstalling,
         eLaunching,
+        eWaitingActive,
         eFinalizing,
     };
 
@@ -38,6 +39,7 @@ public:
             "pending",
             "installing",
             "launching",
+            "activating",
             "finalizing",
         };
 

--- a/src/core/cm/updatemanager/tests/updatemanager.cpp
+++ b/src/core/cm/updatemanager/tests/updatemanager.cpp
@@ -801,26 +801,28 @@ TEST_F(UpdateManagerTest, ProcessFullDesiredStatus)
         .WillOnce(DoAll(SetArgReferee<0>(expectedUnitStatus->mUnitConfig.GetValue()[0]), Return(ErrorEnum::eNone)));
     EXPECT_CALL(mImageManagerMock, GetUpdateItemsStatuses(_))
         .WillOnce(DoAll(SetArgReferee<0>(expectedUnitStatus->mUpdateItems.GetValue()), Return(ErrorEnum::eNone)));
-    EXPECT_CALL(mLauncherMock, GetInstancesStatuses(_)).WillOnce(Invoke([&](Array<InstanceStatus>& instances) {
-        for (const auto& instancesStatuses : expectedUnitStatus->mInstances.GetValue()) {
-            for (const auto& instanceStatus : instancesStatuses.mInstances) {
-                InstanceStatus status;
+    EXPECT_CALL(mLauncherMock, GetInstancesStatuses(_))
+        .Times(2)
+        .WillRepeatedly(Invoke([&](Array<InstanceStatus>& instances) {
+            for (const auto& instancesStatuses : expectedUnitStatus->mInstances.GetValue()) {
+                for (const auto& instanceStatus : instancesStatuses.mInstances) {
+                    InstanceStatus status;
 
-                status.mItemID         = instancesStatuses.mItemID;
-                status.mSubjectID      = instancesStatuses.mSubjectID;
-                status.mVersion        = instancesStatuses.mVersion;
-                status.mInstance       = instanceStatus.mInstance;
-                status.mNodeID         = instanceStatus.mNodeID;
-                status.mRuntimeID      = instanceStatus.mRuntimeID;
-                status.mManifestDigest = instanceStatus.mManifestDigest;
-                status.mState          = instanceStatus.mState;
+                    status.mItemID         = instancesStatuses.mItemID;
+                    status.mSubjectID      = instancesStatuses.mSubjectID;
+                    status.mVersion        = instancesStatuses.mVersion;
+                    status.mInstance       = instanceStatus.mInstance;
+                    status.mNodeID         = instanceStatus.mNodeID;
+                    status.mRuntimeID      = instanceStatus.mRuntimeID;
+                    status.mManifestDigest = instanceStatus.mManifestDigest;
+                    status.mState          = instanceStatus.mState;
 
-                instances.PushBack(status);
+                    instances.PushBack(status);
+                }
             }
-        }
 
-        return ErrorEnum::eNone;
-    }));
+            return ErrorEnum::eNone;
+        }));
 
     auto err = mUpdateManager.ProcessDesiredStatus(*desiredStatus);
     EXPECT_TRUE(err.IsNone()) << "Failed to process desired status: " << tests::utils::ErrorToStr(err);
@@ -910,11 +912,13 @@ TEST_F(UpdateManagerTest, CancelCurrentUpdate)
     EXPECT_CALL(mImageManagerMock, InstallUpdateItems(desiredStatus->mUpdateItems, _)).Times(1);
     EXPECT_CALL(mImageManagerMock, GetUpdateItemsStatuses(_))
         .WillOnce(DoAll(SetArgReferee<0>(expectedUnitStatus->mUpdateItems.GetValue()), Return(ErrorEnum::eNone)));
-    EXPECT_CALL(mLauncherMock, GetInstancesStatuses(_)).WillOnce(Invoke([&](Array<InstanceStatus>& instances) {
-        ConvertInstancesStatuses(expectedUnitStatus->mInstances.GetValue(), instances);
+    EXPECT_CALL(mLauncherMock, GetInstancesStatuses(_))
+        .Times(2)
+        .WillRepeatedly(Invoke([&](Array<InstanceStatus>& instances) {
+            ConvertInstancesStatuses(expectedUnitStatus->mInstances.GetValue(), instances);
 
-        return ErrorEnum::eNone;
-    }));
+            return ErrorEnum::eNone;
+        }));
 
     err = mUpdateManager.ProcessDesiredStatus(*desiredStatus);
     EXPECT_TRUE(err.IsNone()) << "Failed to process desired status: " << tests::utils::ErrorToStr(err);
@@ -994,11 +998,13 @@ TEST_F(UpdateManagerTest, ResumeUpdateAfterRestart)
     EXPECT_CALL(mImageManagerMock, InstallUpdateItems(desiredStatus->mUpdateItems, _)).Times(1);
     EXPECT_CALL(mImageManagerMock, GetUpdateItemsStatuses(_))
         .WillOnce(DoAll(SetArgReferee<0>(expectedUnitStatus->mUpdateItems.GetValue()), Return(ErrorEnum::eNone)));
-    EXPECT_CALL(mLauncherMock, GetInstancesStatuses(_)).WillOnce(Invoke([&](Array<InstanceStatus>& instances) {
-        ConvertInstancesStatuses(expectedUnitStatus->mInstances.GetValue(), instances);
+    EXPECT_CALL(mLauncherMock, GetInstancesStatuses(_))
+        .Times(2)
+        .WillRepeatedly(Invoke([&](Array<InstanceStatus>& instances) {
+            ConvertInstancesStatuses(expectedUnitStatus->mInstances.GetValue(), instances);
 
-        return ErrorEnum::eNone;
-    }));
+            return ErrorEnum::eNone;
+        }));
 
     // Continue update
 


### PR DESCRIPTION
During components update, their instances may stay in activating state some time. Till component update is finished. Update manager should wait all instances go to final state (active, failed or inactive), before finishing processing the current desired status.