### PR TITLE
sm: launcher: do not override non preinstalled instance info

### DIFF
--- a/src/core/sm/launcher/launcher.cpp
+++ b/src/core/sm/launcher/launcher.cpp
@@ -525,6 +525,10 @@ Error Launcher::HandleComponentStatus(const aos::InstanceStatus& status)
         return mStorage->RemoveInstanceInfo(status);
     }
 
+    if (!status.mPreinstalled) {
+        return ErrorEnum::eNone;
+    }
+
     if (mInstances.ContainsIf([&status](const auto& instance) {
             return static_cast<const InstanceIdent&>(instance.mStatus) == static_cast<const InstanceIdent&>(status);
         })) {

--- a/src/core/sm/launcher/tests/launcher.cpp
+++ b/src/core/sm/launcher/tests/launcher.cpp
@@ -66,7 +66,8 @@ namespace {
  * Static
  **********************************************************************************************************************/
 
-InstanceInfo CreateInstanceInfo(const String& itemID, uint64_t instance, const String& version, const String& runtimeID)
+InstanceInfo CreateInstanceInfo(const String& itemID, uint64_t instance, const String& version, const String& runtimeID,
+    const UpdateItemType& type = UpdateItemTypeEnum::eService)
 {
     InstanceInfo info;
 
@@ -75,6 +76,7 @@ InstanceInfo CreateInstanceInfo(const String& itemID, uint64_t instance, const S
     info.mInstance  = instance;
     info.mVersion   = version;
     info.mRuntimeID = runtimeID;
+    info.mType      = type;
 
     return info;
 }
@@ -242,6 +244,12 @@ TEST_F(LauncherTest, SendActiveComponentNodeInstancesStatusOnModuleStart)
         CreateInstanceStatus(CreateInstanceInfo("item2", 2, "1.0.0", "runtime0"), InstanceStateEnum::eActive,
             UpdateItemTypeEnum::eService),
     };
+
+    const std::vector cStoredInfos = {
+        CreateInstanceInfo("item0", 0, "1.0.1", "runtime0", UpdateItemTypeEnum::eComponent),
+    };
+
+    mStorage.Init(cStoredInfos);
 
     const auto cActiveComponent = static_cast<const InstanceIdent&>(cRuntime0Components[0]);
 


### PR DESCRIPTION
Only preinstalled instances should be inserted/updated in storage on instance status update, as it's the way launcher recives information about preinstalled instances.
Non preinstalled instances are added to storage on update instances request, and their info should not be overridden on status update.