### PR TITLE
sm: networkmanager: extend InterfaceFactoryItf with CreateLink

### DIFF
--- a/src/core/sm/networkmanager/itf/interfacefactory.hpp
+++ b/src/core/sm/networkmanager/itf/interfacefactory.hpp
@@ -40,6 +40,19 @@ public:
     virtual Error CreateVlan(const String& name, uint64_t vlanID) = 0;
 
     /**
+     * Creates a parameter-less link of the given kind (e.g. "ifb", "dummy").
+     *
+     * For link kinds that need only a name and a type. Other typed factories
+     * (CreateBridge, CreateVlan, ...) remain the preferred entry point when
+     * extra attributes are required.
+     *
+     * @param name link name.
+     * @param kind link kind (rtnetlink link-type string).
+     * @return Error.
+     */
+    virtual Error CreateLink(const String& name, const String& kind) = 0;
+
+    /**
      * Destructor.
      */
     virtual ~InterfaceFactoryItf() = default;

--- a/src/core/sm/networkmanager/tests/mocks/interfacefactorymock.hpp
+++ b/src/core/sm/networkmanager/tests/mocks/interfacefactorymock.hpp
@@ -17,6 +17,7 @@ class InterfaceFactoryMock : public InterfaceFactoryItf {
 public:
     MOCK_METHOD(Error, CreateBridge, (const String&, const String&, const String&), (override));
     MOCK_METHOD(Error, CreateVlan, (const String&, uint64_t), (override));
+    MOCK_METHOD(Error, CreateLink, (const String&, const String&), (override));
 };
 
 } // namespace aos::sm::networkmanager


### PR DESCRIPTION
Adds a parameter-less link factory method (name + kind) alongside the existing CreateBridge / CreateVlan typed factories. The CNI bandwidth replacement needs to create an IFB pseudo-device per shaped instance; since IFB has no attributes beyond name + type, a single generic CreateLink fits the factory pattern better than introducing a typed CreateIFB. Other parameter-less link kinds (e.g. "dummy") can reuse it without further interface changes.