### PR TITLE
updatemanager: fix deadlock on waiting all instances active

### DIFF
--- a/src/core/cm/updatemanager/desiredstatushandler.cpp
+++ b/src/core/cm/updatemanager/desiredstatushandler.cpp
@@ -151,8 +151,6 @@ void DesiredStatusHandler::OnInstancesStatusesChanged(const Array<InstanceStatus
 {
     (void)statuses;
 
-    LockGuard lock {mMutex};
-
     mCondVar.NotifyOne();
 }
 
@@ -460,8 +458,6 @@ Error DesiredStatusHandler::LaunchInstances()
 
 Error DesiredStatusHandler::WaitInstancesActive()
 {
-    UniqueLock lock {mMutex};
-
     auto instancesStatuses = MakeUnique<StaticArray<InstanceStatus, cMaxNumInstances>>(&mAllocator);
 
     while (mIsRunning) {
@@ -482,6 +478,8 @@ Error DesiredStatusHandler::WaitInstancesActive()
         if (allActive) {
             break;
         }
+
+        UniqueLock lock {mMutex};
 
         if (auto err = mCondVar.Wait(lock, cWaitActiveTimeout); !err.IsNone()) {
             return AOS_ERROR_WRAP(err);


### PR DESCRIPTION
Deadlock Analysis

Classic ABBA deadlock between two threads:

Mutex A: Launcher::mUpdateMutex (at 0x7f79c60423e0)

Mutex B: DesiredStatusHandler::mMutex (at 0x7f79c6936620)

---
Thread 37 (LWP 1035) — grpc SMHandler thread

Holds Mutex A, waiting for Mutex B:

SMHandler::ProcessMessages
 → SMHandler::ProcessNodeInstancesStatus        smhandler.cpp:359
  → Launcher::OnNodeInstancesStatusesReceived  launcher.cpp:611  ← acquires
    mUpdateMutex (A)
   → Launcher::UpdateInstanceStatuses         launcher.cpp:631
    → DesiredStatusHandler::OnInstancesStatusesChanged
      desiredstatushandler.cpp:154
     → pthread_mutex_lock(mMutex)           ← BLOCKED waiting for B

  OnInstancesStatusesChanged does:
  void DesiredStatusHandler::OnInstancesStatusesChanged(...) {
      LockGuard lock {mMutex};   // tries to acquire B — BLOCKED
      mCondVar.NotifyOne();
  }

---
Thread 26 (LWP 995) — DesiredStatusHandler::Run thread

Holds Mutex B, waiting for Mutex A:

DesiredStatusHandler::Run            desiredstatushandler.cpp:251
  (calls with lock.Unlock()!)
 → DesiredStatusHandler::WaitInstancesActive  desiredstatushandler.cpp:463  ←
   acquires mMutex (B)
  → Launcher::GetInstancesStatuses  launcher.cpp:261
   → LockGuard updateLock {mUpdateMutex}   ← BLOCKED waiting for A

WaitInstancesActive does: Error DesiredStatusHandler::WaitInstancesActive() {
  UniqueLock lock {mMutex};        // holds B
    while (mIsRunning) {
      mLauncher->GetInstancesStatuses(...)  // tries to acquire A — BLOCKED

The fix is in OnInstancesStatusesChanged — NotifyOne() does not require holding the mutex. Remove the lock guard there. And acquire mMutex in WaitInstancesActive after calling GetInstancesStatuses.