### PR TITLE
sm: networkmanager: pass instance subnet to firewall

### DIFF
--- a/src/core/sm/networkmanager/itf/firewall.hpp
+++ b/src/core/sm/networkmanager/itf/firewall.hpp
@@ -43,7 +43,11 @@ struct OutputAccessConfig {
  * Per-instance firewall parameters.
  */
 struct InstanceFirewallParams {
-    StaticString<cIPLen>                                  mIP;
+    StaticString<cIPLen> mIP;
+    // Subnet (CIDR) of the instance network. Instances sharing it (same
+    // network) communicate without restrictions; only cross-network traffic
+    // is filtered by the access rules below.
+    StaticString<cSubnetLen>                              mSubnet;
     bool                                                  mAllowPublic {};
     StaticArray<InputAccessConfig, cMaxNumFirewallRules>  mInput;
     StaticArray<OutputAccessConfig, cMaxNumFirewallRules> mOutput;

--- a/src/core/sm/networkmanager/networkmanager.cpp
+++ b/src/core/sm/networkmanager/networkmanager.cpp
@@ -1395,6 +1395,7 @@ Error NetworkManager::PrepareInstanceFirewallParams(const InstanceNetworkConfig&
     const aos::InstanceNetworkAllocation& networkParams, InstanceFirewallParams& params) const
 {
     params.mIP          = networkParams.mIP;
+    params.mSubnet      = networkParams.mSubnet;
     params.mAllowPublic = true;
 
     StaticArray<StaticString<cPortLen>, cMaxExposedPort> portConfig;


### PR DESCRIPTION
Add mSubnet to InstanceFirewallParams and populate it from the instance network allocation. This lets the service manager firewall recognise the instance's own network (subnet) and allow unrestricted communication between instances that share it, while still filtering cross-network traffic.