### PR TITLE
cm: updatemanager: store instance statuses in flat pointer-based array

### DIFF
--- a/src/core/cm/updatemanager/tests/updatemanager.cpp
+++ b/src/core/cm/updatemanager/tests/updatemanager.cpp
@@ -41,6 +41,13 @@ const auto                cCVTimeout             = std::chrono::seconds(5);
  * Static
  **********************************************************************************************************************/
 
+static StaticArray<UnitInstanceStatus, cMaxNumInstances> sInstanceStatusStorage;
+
+void ResetInstanceStatusStorage()
+{
+    sInstanceStatusStorage.Clear();
+}
+
 void SetNodeInfo(UnitNodeInfo& nodeInfo, const String& nodeID, const String& nodeType,
     const NodeState& state = NodeStateEnum::eProvisioned, bool isConnected = true, Error error = ErrorEnum::eNone)
 {
@@ -151,15 +158,19 @@ void CreateInstancesStatuses(UnitStatus& unitStatus, const String& itemID, const
     instancesStatuses.mPreinstalled = preinstalled;
 
     for (size_t i = 0; i < numInstances; i++) {
-        UnitInstanceStatus instanceStatus;
+        auto err = sInstanceStatusStorage.EmplaceBack();
+        EXPECT_TRUE(err.IsNone());
 
+        auto& instanceStatus = sInstanceStatusStorage.Back();
+
+        instanceStatus                 = {};
         instanceStatus.mInstance       = i;
         instanceStatus.mManifestDigest = "digest1";
         instanceStatus.mNodeID         = "node1";
         instanceStatus.mRuntimeID      = "runtime1";
         instanceStatus.mState          = state;
 
-        auto err = instancesStatuses.mInstances.PushBack(instanceStatus);
+        err = instancesStatuses.mInstances.PushBack(&instanceStatus);
         EXPECT_TRUE(err.IsNone());
     }
 }
@@ -179,15 +190,19 @@ void ChangeInstancesStatuses(UnitStatus& unitStatus, const String& itemID, const
     instancesStatuses.mInstances.Clear();
 
     for (size_t i = 0; i < numInstances; i++) {
-        UnitInstanceStatus instanceStatus;
+        auto err = sInstanceStatusStorage.EmplaceBack();
+        EXPECT_TRUE(err.IsNone());
 
+        auto& instanceStatus = sInstanceStatusStorage.Back();
+
+        instanceStatus                 = {};
         instanceStatus.mInstance       = i;
         instanceStatus.mManifestDigest = "digest1";
         instanceStatus.mNodeID         = "node1";
         instanceStatus.mRuntimeID      = "runtime1";
         instanceStatus.mState          = state;
 
-        auto err = instancesStatuses.mInstances.PushBack(instanceStatus);
+        err = instancesStatuses.mInstances.PushBack(&instanceStatus);
         EXPECT_TRUE(err.IsNone());
     }
 }
@@ -295,11 +310,11 @@ void ConvertInstancesStatuses(
             status.mType           = unitInstanceStatus.mType;
             status.mSubjectID      = unitInstanceStatus.mSubjectID;
             status.mVersion        = unitInstanceStatus.mVersion;
-            status.mInstance       = instanceStatus.mInstance;
-            status.mNodeID         = instanceStatus.mNodeID;
-            status.mRuntimeID      = instanceStatus.mRuntimeID;
-            status.mManifestDigest = instanceStatus.mManifestDigest;
-            status.mState          = instanceStatus.mState;
+            status.mInstance       = instanceStatus->mInstance;
+            status.mNodeID         = instanceStatus->mNodeID;
+            status.mRuntimeID      = instanceStatus->mRuntimeID;
+            status.mManifestDigest = instanceStatus->mManifestDigest;
+            status.mState          = instanceStatus->mState;
             status.mPreinstalled   = unitInstanceStatus.mPreinstalled;
 
             instancesStatuses.PushBack(status);
@@ -324,6 +339,8 @@ protected:
 
     void SetUp() override
     {
+        ResetInstanceStatusStorage();
+
         Config config {cUnitStatusSendTimeout};
 
         auto err = mUpdateManager.Init(config, mIdentProviderMock, mNodeHandlerMock, mUnitConfigMock,
@@ -608,7 +625,7 @@ TEST_F(UpdateManagerTest, SendDeltaUnitStatus)
             EXPECT_TRUE(err.IsNone());
 
             CreateInstanceStatus(statuses->Back(), instancesStatuses.mItemID, instancesStatuses.mSubjectID,
-                instanceStatus.mInstance, instancesStatuses.mVersion, instanceStatus);
+                instanceStatus->mInstance, instancesStatuses.mVersion, *instanceStatus);
         }
     }
 
@@ -627,7 +644,7 @@ TEST_F(UpdateManagerTest, SendDeltaUnitStatus)
             EXPECT_TRUE(err.IsNone());
 
             CreateInstanceStatus(statuses->Back(), instancesStatuses.mItemID, instancesStatuses.mSubjectID,
-                instanceStatus.mInstance, instancesStatuses.mVersion, instanceStatus);
+                instanceStatus->mInstance, instancesStatuses.mVersion, *instanceStatus);
         }
     }
 
@@ -811,11 +828,11 @@ TEST_F(UpdateManagerTest, ProcessFullDesiredStatus)
                     status.mItemID         = instancesStatuses.mItemID;
                     status.mSubjectID      = instancesStatuses.mSubjectID;
                     status.mVersion        = instancesStatuses.mVersion;
-                    status.mInstance       = instanceStatus.mInstance;
-                    status.mNodeID         = instanceStatus.mNodeID;
-                    status.mRuntimeID      = instanceStatus.mRuntimeID;
-                    status.mManifestDigest = instanceStatus.mManifestDigest;
-                    status.mState          = instanceStatus.mState;
+                    status.mInstance       = instanceStatus->mInstance;
+                    status.mNodeID         = instanceStatus->mNodeID;
+                    status.mRuntimeID      = instanceStatus->mRuntimeID;
+                    status.mManifestDigest = instanceStatus->mManifestDigest;
+                    status.mState          = instanceStatus->mState;
 
                     instances.PushBack(status);
                 }

--- a/src/core/cm/updatemanager/unitstatushandler.cpp
+++ b/src/core/cm/updatemanager/unitstatushandler.cpp
@@ -311,20 +311,25 @@ void UnitStatusHandler::OnInstancesStatusesChanged(const Array<InstanceStatus>& 
             itemIt = &mUnitStatus.mInstances->Back();
         }
 
-        auto instanceIt = itemIt->mInstances.FindIf([&status](const UnitInstanceStatus& instanceStatus) {
-            return instanceStatus.mInstance == status.mInstance;
+        auto instanceIt = itemIt->mInstances.FindIf([&status](const UnitInstanceStatus* instanceStatus) {
+            return instanceStatus->mInstance == status.mInstance;
         });
         if (instanceIt == itemIt->mInstances.end()) {
-            if (auto err = itemIt->mInstances.EmplaceBack(); !err.IsNone()) {
+            if (auto err = mUnitInstancesStatuses.EmplaceBack(); !err.IsNone()) {
                 LOG_ERR() << "Failed to emplace instance status" << Log::Field(err);
+                return;
+            }
+
+            if (auto err = itemIt->mInstances.PushBack(&mUnitInstancesStatuses.Back()); !err.IsNone()) {
+                LOG_ERR() << "Failed to push instance status pointer" << Log::Field(err);
                 return;
             }
 
             instanceIt = &itemIt->mInstances.Back();
         }
 
-        static_cast<InstanceStatusData&>(*instanceIt) = static_cast<const InstanceStatusData&>(status);
-        instanceIt->mInstance                         = status.mInstance;
+        static_cast<InstanceStatusData&>(**instanceIt) = static_cast<const InstanceStatusData&>(status);
+        (*instanceIt)->mInstance                       = status.mInstance;
     }
 
     StartTimer();
@@ -460,6 +465,7 @@ Error UnitStatusHandler::SetUpdateItemsStatus()
 Error UnitStatusHandler::SetInstancesStatus()
 {
     mUnitStatus.mInstances.EmplaceValue();
+    mUnitInstancesStatuses.Clear();
 
     auto instancesStatuses = MakeUnique<StaticArray<InstanceStatus, cMaxNumInstances>>(&mAllocator);
 
@@ -482,12 +488,16 @@ Error UnitStatusHandler::SetInstancesStatus()
             it = &mUnitStatus.mInstances->Back();
         }
 
-        UnitInstanceStatus instanceStatus {};
+        if (auto err = mUnitInstancesStatuses.EmplaceBack(); !err.IsNone()) {
+            return AOS_ERROR_WRAP(err);
+        }
+
+        auto& instanceStatus = mUnitInstancesStatuses.Back();
 
         static_cast<InstanceStatusData&>(instanceStatus) = static_cast<const InstanceStatusData&>(status);
         instanceStatus.mInstance                         = status.mInstance;
 
-        it->mInstances.PushBack(instanceStatus);
+        it->mInstances.PushBack(&instanceStatus);
     }
 
     return ErrorEnum::eNone;
@@ -534,11 +544,11 @@ void UnitStatusHandler::LogUnitStatus()
                       << Log::Field("version", instanceStatuses.mVersion);
 
             for (const auto& instanceStatus : instanceStatuses.mInstances) {
-                LOG_INF() << "Unit status instance" << Log::Field("instance", instanceStatus.mInstance)
-                          << Log::Field("manifestDigest", instanceStatus.mManifestDigest)
-                          << Log::Field("nodeID", instanceStatus.mNodeID)
-                          << Log::Field("runtimeID", instanceStatus.mRuntimeID)
-                          << Log::Field("state", instanceStatus.mState) << Log::Field(instanceStatus.mError);
+                LOG_INF() << "Unit status instance" << Log::Field("instance", instanceStatus->mInstance)
+                          << Log::Field("manifestDigest", instanceStatus->mManifestDigest)
+                          << Log::Field("nodeID", instanceStatus->mNodeID)
+                          << Log::Field("runtimeID", instanceStatus->mRuntimeID)
+                          << Log::Field("state", instanceStatus->mState) << Log::Field(instanceStatus->mError);
             }
         }
     }

--- a/src/core/cm/updatemanager/unitstatushandler.hpp
+++ b/src/core/cm/updatemanager/unitstatushandler.hpp
@@ -131,11 +131,12 @@ private:
     cloudconnection::CloudConnectionItf*   mCloudConnection {};
     SenderItf*                             mSender {};
 
-    Mutex                           mMutex;
-    UnitStatus                      mUnitStatus;
-    StaticAllocator<cAllocatorSize> mAllocator;
-    bool                            mCloudConnected {};
-    bool                            mIsStatusProcessing {};
+    Mutex                                             mMutex;
+    UnitStatus                                        mUnitStatus;
+    StaticArray<UnitInstanceStatus, cMaxNumInstances> mUnitInstancesStatuses;
+    StaticAllocator<cAllocatorSize>                   mAllocator;
+    bool                                              mCloudConnected {};
+    bool                                              mIsStatusProcessing {};
 
     Timer    mTimer;
     bool     mTimerStarted {};

--- a/src/core/common/config.hpp
+++ b/src/core/common/config.hpp
@@ -149,13 +149,6 @@
 #endif
 
 /**
- * Max number of instances per update item.
- */
-#ifndef AOS_CONFIG_TYPES_MAX_NUM_UPDATE_ITEM_INSTANCES
-#define AOS_CONFIG_TYPES_MAX_NUM_UPDATE_ITEM_INSTANCES 16
-#endif
-
-/**
  * Error message len.
  */
 #ifndef AOS_CONFIG_TYPES_ERROR_MESSAGE_LEN

--- a/src/core/common/types/common.hpp
+++ b/src/core/common/types/common.hpp
@@ -45,11 +45,6 @@ constexpr auto cMaxNumUpdateItems = AOS_CONFIG_TYPES_MAX_NUM_UPDATE_ITEMS;
 constexpr auto cMaxNumBlobs = AOS_CONFIG_TYPES_MAX_NUM_BLOBS;
 
 /**
- * Max number of instances per update item.
- */
-constexpr auto cMaxNumUpdateItemInstances = AOS_CONFIG_TYPES_MAX_NUM_UPDATE_ITEM_INSTANCES;
-
-/**
  * Max number of instances.
  */
 constexpr auto cMaxNumInstances = AOS_CONFIG_TYPES_MAX_NUM_INSTANCES;

--- a/src/core/common/types/unitstatus.hpp
+++ b/src/core/common/types/unitstatus.hpp
@@ -109,7 +109,7 @@ struct UnitInstanceStatus : public InstanceStatusData {
     bool operator!=(const UnitInstanceStatus& rhs) const { return !operator==(rhs); }
 };
 
-using UnitInstanceStatusArray = StaticArray<UnitInstanceStatus, cMaxNumUpdateItemInstances>;
+using UnitInstanceStatusArray = StaticArray<UnitInstanceStatus*, cMaxNumInstances>;
 
 /**
  * Instances statuses.
@@ -153,8 +153,18 @@ struct UnitInstancesStatuses {
      */
     bool operator==(const UnitInstancesStatuses& rhs) const
     {
+        if (mInstances.Size() != rhs.mInstances.Size()) {
+            return false;
+        }
+
+        for (size_t i = 0; i < mInstances.Size(); i++) {
+            if (*mInstances[i] != *rhs.mInstances[i]) {
+                return false;
+            }
+        }
+
         return mItemID == rhs.mItemID && mType == rhs.mType && mSubjectID == rhs.mSubjectID && mVersion == rhs.mVersion
-            && mPreinstalled == rhs.mPreinstalled && mInstances == rhs.mInstances;
+            && mPreinstalled == rhs.mPreinstalled;
     }
 
     /**


### PR DESCRIPTION
Replace per-item StaticArray<UnitInstanceStatus, N> with a flat StaticArray<UnitInstanceStatus*, cMaxNumInstances> in UnitInstancesStatuses, backed by mUnitInstancesStatuses owned by UnitStatusHandler. This removes the per-item instance limit and avoids large inline storage inside each UnitInstancesStatuses entry.

Remove cMaxNumUpdateItemInstances constant as it is no longer needed.

Update UnitInstancesStatuses::operator== to dereference pointers for deep value comparison. Update tests accordingly.