### PR TITLE
sm: launcher: fix instance data invalidation on remove

### DIFF
--- a/src/core/sm/launcher/launcher.cpp
+++ b/src/core/sm/launcher/launcher.cpp
@@ -1112,7 +1112,7 @@ RetWithError<Launcher::InstanceData*> Launcher::AddInstanceData(const InstanceIn
     return itInstance;
 }
 
-Error Launcher::RemoveInstance(InstanceData& instanceData)
+Error Launcher::ReleaseInstance(InstanceData& instanceData)
 {
     LOG_DBG() << "Remove instance" << Log::Field("instance", instanceData.mInfo);
 
@@ -1128,18 +1128,6 @@ Error Launcher::RemoveInstance(InstanceData& instanceData)
 
     if (auto err = mNetworkManager->ReleaseInstanceNetwork(instanceID, instanceData.mInfo.mOwnerID); !err.IsNone()) {
         return AOS_ERROR_WRAP(err);
-    }
-
-    LockGuard lock {mMutex};
-
-    LOG_DBG() << "Remove instance data" << Log::Field("instance", instanceData.mInfo);
-
-    if (auto count = mInstances.RemoveIf([this, &instanceData](const auto& instance) {
-            return static_cast<const InstanceIdent&>(instance.mInfo)
-                == static_cast<const InstanceIdent&>(instanceData.mInfo);
-        });
-        count == 0) {
-        return AOS_ERROR_WRAP(ErrorEnum::eNotFound);
     }
 
     return ErrorEnum::eNone;
@@ -1163,7 +1151,7 @@ void Launcher::RemoveInstances(const Array<InstanceIdent>& instances)
         }
 
         if (auto err = mLaunchPool.AddTask([this, instanceData](void*) {
-                if (auto err = RemoveInstance(*instanceData); !err.IsNone()) {
+                if (auto err = ReleaseInstance(*instanceData); !err.IsNone()) {
                     LOG_ERR() << "Failed to remove instance" << Log::Field("instance", instanceData->mInfo)
                               << Log::Field(AOS_ERROR_WRAP(err));
 
@@ -1180,6 +1168,27 @@ void Launcher::RemoveInstances(const Array<InstanceIdent>& instances)
 
     if (auto err = mLaunchPool.Wait(); !err.IsNone()) {
         LOG_ERR() << "Thread pool wait failed" << Log::Field(AOS_ERROR_WRAP(err));
+    }
+
+    LockGuard lock {mMutex};
+
+    for (const auto& instanceIdent : instances) {
+        LOG_DBG() << "Remove instance data" << Log::Field("instance", instanceIdent);
+
+        mInstances.RemoveIf([this, &instanceIdent](const auto& instance) {
+            if (static_cast<const InstanceIdent&>(instance.mInfo) != instanceIdent) {
+                return false;
+            }
+
+            if (instance.mStatus.mState != InstanceStateEnum::eInactive) {
+                LOG_ERR() << "Instance is not inactive, skip removing" << Log::Field("instance", instanceIdent)
+                          << Log::Field("state", instance.mStatus.mState);
+
+                return false;
+            }
+
+            return true;
+        });
     }
 }
 

--- a/src/core/sm/launcher/launcher.hpp
+++ b/src/core/sm/launcher/launcher.hpp
@@ -208,7 +208,7 @@ private:
     void  RemoveUpdateItems(const Array<UpdateItemInfo>& removeItems);
     void  InstallUpdateItems(const Array<InstanceInfo>& startInstances);
     RetWithError<InstanceData*> AddInstanceData(const InstanceInfo& instanceInfo);
-    Error                       RemoveInstance(InstanceData& instanceData);
+    Error                       ReleaseInstance(InstanceData& instanceData);
     void                        RemoveInstances(const Array<InstanceIdent>& instances);
     void  SetInstanceState(InstanceData& instance, const InstanceState& state, const Error& error = ErrorEnum::eNone);
     Error GetInstanceConfigs(const InstanceInfo& instance, oci::ItemConfig& itemConfig, oci::ImageConfig& imageConfig);


### PR DESCRIPTION
RemoveInstances scheduled each instance removal as a concurrent task on the launch pool, and every task captured a raw InstanceData* pointing into mInstances. RemoveInstance erased its own entry from mInstances as soon as it finished, which shifts trailing elements down to fill the gap. Other tasks still running concurrently held pointers into those now-shifted (or destructed) slots, so they ended up reading and writing the wrong instance, or freed memory.

Split the work instead: tasks now only release external resources (storage entry, network) via the renamed ReleaseInstance, without touching mInstances. The actual removal from mInstances happens in a single serial pass after mLaunchPool.Wait(), under mMutex, once no task can be holding a pointer into the array anymore. Each entry is re-checked for the eInactive state at removal time, so instances that failed to stop or failed release (now marked eFailed) are left in place instead of being purged.