### PR TITLE
sm: launcher: skip loading data for non-service instances

### DIFF
--- a/src/core/sm/launcher/launcher.cpp
+++ b/src/core/sm/launcher/launcher.cpp
@@ -1284,13 +1284,6 @@ void Launcher::RemoveInstances(const Array<InstanceIdent>& instances)
             continue;
         }
 
-        if (instanceData->mStatus.mState != InstanceStateEnum::eInactive) {
-            LOG_ERR() << "Instance is not inactive, skip removing" << Log::Field("instance", instanceIdent)
-                      << Log::Field("state", instanceData->mStatus.mState);
-
-            continue;
-        }
-
         if (auto err = mLaunchPool.AddTask([this, instanceData](void*) {
                 if (auto err = ReleaseInstance(*instanceData); !err.IsNone()) {
                     LOG_ERR() << "Failed to remove instance" << Log::Field("instance", instanceData->mInfo)
@@ -1317,18 +1310,7 @@ void Launcher::RemoveInstances(const Array<InstanceIdent>& instances)
         LOG_DBG() << "Remove instance data" << Log::Field("instance", instanceIdent);
 
         mInstances.RemoveIf([this, &instanceIdent](const auto& instance) {
-            if (static_cast<const InstanceIdent&>(instance.mInfo) != instanceIdent) {
-                return false;
-            }
-
-            if (instance.mStatus.mState != InstanceStateEnum::eInactive) {
-                LOG_ERR() << "Instance is not inactive, skip removing" << Log::Field("instance", instanceIdent)
-                          << Log::Field("state", instance.mStatus.mState);
-
-                return false;
-            }
-
-            return true;
+            return static_cast<const InstanceIdent&>(instance.mInfo) == instanceIdent;
         });
     }
 }

--- a/src/core/sm/launcher/launcher.cpp
+++ b/src/core/sm/launcher/launcher.cpp
@@ -600,6 +600,10 @@ void Launcher::LoadInstancesData(const Array<InstanceInfo>& storedInstances)
             continue;
         }
 
+        if (instanceData->mInfo.mType != UpdateItemTypeEnum::eService) {
+            continue;
+        }
+
         if (err = mLaunchPool.AddTask([this, instanceData](void*) {
                 if (auto err = LoadInstanceData(*instanceData); !err.IsNone()) {
                     LOG_ERR() << "Failed to load instance data" << Log::Field("instance", instanceData->mInfo)

--- a/src/core/sm/networkmanager/networkmanager.hpp
+++ b/src/core/sm/networkmanager/networkmanager.hpp
@@ -211,6 +211,13 @@ private:
         + sizeof(StaticArray<InstanceNetworkStateInfo, cMaxNumInstances>);
     static constexpr auto cNumAllocations = 8 * cMaxNumConcurrentItems;
 
+    // GetHosts/GetResolvServers are const methods that instance start/stop pool tasks call
+    // concurrently (one call per in-flight instance), each making a single allocation off
+    // mResolvHostsAllocator that stays alive for the call's duration. Size it for
+    // cMaxNumConcurrentItems concurrent callers instead of just one.
+    static constexpr auto cResolvHostsAllocatorSize = cMaxNumConcurrentItems
+        * (sizeof(StaticArray<Host, cMaxNumHosts>) + sizeof(StaticArray<StaticString<cIPLen>, cMaxNumDNSServers>));
+
     static constexpr uint64_t cBurstLen              = 12800;
     static constexpr auto     cMaxExposedPort        = 2;
     static constexpr auto     cCountRetriesIfNameGen = 10;
@@ -283,11 +290,9 @@ private:
     StaticAllocator<sizeof(StaticArray<NetworkInfo, cMaxNumOwners>)>                       mNetworkInfosAllocator;
     StaticAllocator<sizeof(StaticArray<InstanceNetworkInfo, cMaxNumInstances>)> mInstanceNetworkInfosAllocator;
 
-    mutable Mutex                                    mMutex;
-    StaticAllocator<cAllocatorSize, cNumAllocations> mAllocator;
-    mutable StaticAllocator<sizeof(StaticArray<Host, cMaxNumHosts>)
-        + sizeof(StaticArray<StaticString<cIPLen>, cMaxNumDNSServers>)>
-        mResolvHostsAllocator;
+    mutable Mutex                                                                  mMutex;
+    StaticAllocator<cAllocatorSize, cNumAllocations>                               mAllocator;
+    mutable StaticAllocator<cResolvHostsAllocatorSize, 2 * cMaxNumConcurrentItems> mResolvHostsAllocator;
 };
 
 /** @}*/


### PR DESCRIPTION
LoadInstancesData iterated over all stored instances and scheduled LoadInstanceData for each of them, including components. Component instances do not have image/item configs to load, so this caused load failures to be logged for every stored component on startup. Skip instances whose type is not eService before scheduling the load task.