### PR TITLE
sm: networkmanager: guard concurrent last-instance network teardown

### DIFF
--- a/src/core/sm/networkmanager/networkmanager.cpp
+++ b/src/core/sm/networkmanager/networkmanager.cpp
@@ -493,6 +493,10 @@ Error NetworkManager::ReleaseInstanceNetwork(const String& instanceID, const Str
             return ErrorEnum::eNone;
         }
 
+        if (mNetworkProviders.Find(networkID) == mNetworkProviders.end()) {
+            return ErrorEnum::eNone;
+        }
+
         mNetworkProviders.Remove(networkID);
     }
 


### PR DESCRIPTION
RemoveInstances releases instances as parallel launch-pool tasks, so several ReleaseInstanceNetwork calls for the last instances on a shared network can run concurrently. Each removes its own entry from mInstanceNetworkInfos first, so both then observe no instances left and each tears the network down (storage RemoveNetworkInfo + CM ReleaseNodeNetwork), the second failing with "not found".

Claim the teardown atomically via mNetworkProviders under the lock: only the release that still finds the network present removes it and proceeds to clean up storage and the CM.