### PR TITLE
fix: update badges and restrict codecov to main branch

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -54,6 +54,7 @@ jobs:
           ./build.sh coverage
 
       - name: Upload codecov report
+        if: github.event_name == 'push'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,21 @@
 <!-- markdownlint-disable-next-line MD041 -->
-[![ci](https://github.com/aosedge/aos_core_lib_cpp/actions/workflows/build_test.yaml/badge.svg)](https://github.com/aosedge/aos_core_lib_cpp/actions/workflows/build_test.yaml)
-[![codecov](https://codecov.io/gh/aosedge/aos_core_lib_cpp/graph/badge.svg?token=kg8h7ATd9S)](https://codecov.io/gh/aosedge/aos_core_lib_cpp)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=aosedge_aos_core_lib_cpp&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=aosedge_aos_core_lib_cpp)
+| Branch | CI | Coverage | Quality Gate |
+|--------|----|----------|--------------|
+| main | [![ci][ci-main]][ci-main-link] | [![coverage][cov-main]][cov-main-link] | [![Quality Gate][qg-main]][qg-main-link] |
+| develop | [![ci][ci-dev]][ci-dev-link] | [![coverage][cov-dev]][cov-dev-link] | [![Quality Gate][qg-dev]][qg-dev-link] |
+
+[ci-main]: https://github.com/aosedge/aos_core_lib_cpp/actions/workflows/build-test.yaml/badge.svg?branch=main
+[ci-main-link]: https://github.com/aosedge/aos_core_lib_cpp/actions/workflows/build-test.yaml?query=branch%3Amain
+[cov-main]: https://sonarcloud.io/api/project_badges/measure?project=aosedge_aos_core_lib_cpp&metric=coverage&branch=main
+[cov-main-link]: https://sonarcloud.io/summary/new_code?id=aosedge_aos_core_lib_cpp&branch=main
+[qg-main]: https://sonarcloud.io/api/project_badges/measure?project=aosedge_aos_core_lib_cpp&metric=alert_status&branch=main
+[qg-main-link]: https://sonarcloud.io/summary/new_code?id=aosedge_aos_core_lib_cpp&branch=main
+[ci-dev]: https://github.com/aosedge/aos_core_lib_cpp/actions/workflows/build-test.yaml/badge.svg?branch=develop
+[ci-dev-link]: https://github.com/aosedge/aos_core_lib_cpp/actions/workflows/build-test.yaml?query=branch%3Adevelop
+[cov-dev]: https://sonarcloud.io/api/project_badges/measure?project=aosedge_aos_core_lib_cpp&metric=coverage&branch=develop
+[cov-dev-link]: https://sonarcloud.io/summary/new_code?id=aosedge_aos_core_lib_cpp&branch=develop
+[qg-dev]: https://sonarcloud.io/api/project_badges/measure?project=aosedge_aos_core_lib_cpp&metric=alert_status&branch=develop
+[qg-dev-link]: https://sonarcloud.io/summary/new_code?id=aosedge_aos_core_lib_cpp&branch=develop
 
 # AosCore cpp libraries
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,21 @@
+codecov:
+  branch: main
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: 80%
+        informational: true
+
+ignore:
+  - "**/tests/**"
+
+branches:
+  - main
+  - develop


### PR DESCRIPTION
- Fix CI badge URL (build_test.yaml -> build-test.yaml)
- Replace Codecov badge with SonarCloud coverage badge
- Add branch=main filter to CI badge
- Restrict codecov upload to main branch only