### PR TITLE
ci: simplify README badges to main branch only

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 <!-- markdownlint-disable-next-line MD041 -->
-| Branch | CI | Coverage | Quality Gate |
-|--------|----|----------|--------------|
-| main | [![ci][ci-main]][ci-main-link] | [![coverage][cov-main]][cov-main-link] | [![Quality Gate][qg-main]][qg-main-link] |
-| develop | [![ci][ci-dev]][ci-dev-link] | [![coverage][cov-dev]][cov-dev-link] | [![Quality Gate][qg-dev]][qg-dev-link] |
+[![ci][ci-main]][ci-main-link]
+[![coverage][cov-main]][cov-main-link]
+[![Quality Gate][qg-main]][qg-main-link]
 
 [ci-main]: https://github.com/aosedge/aos_core_lib_cpp/actions/workflows/build-test.yaml/badge.svg?branch=main
 [ci-main-link]: https://github.com/aosedge/aos_core_lib_cpp/actions/workflows/build-test.yaml?query=branch%3Amain
@@ -10,12 +9,6 @@
 [cov-main-link]: https://sonarcloud.io/summary/new_code?id=aosedge_aos_core_lib_cpp&branch=main
 [qg-main]: https://sonarcloud.io/api/project_badges/measure?project=aosedge_aos_core_lib_cpp&metric=alert_status&branch=main
 [qg-main-link]: https://sonarcloud.io/summary/new_code?id=aosedge_aos_core_lib_cpp&branch=main
-[ci-dev]: https://github.com/aosedge/aos_core_lib_cpp/actions/workflows/build-test.yaml/badge.svg?branch=develop
-[ci-dev-link]: https://github.com/aosedge/aos_core_lib_cpp/actions/workflows/build-test.yaml?query=branch%3Adevelop
-[cov-dev]: https://sonarcloud.io/api/project_badges/measure?project=aosedge_aos_core_lib_cpp&metric=coverage&branch=develop
-[cov-dev-link]: https://sonarcloud.io/summary/new_code?id=aosedge_aos_core_lib_cpp&branch=develop
-[qg-dev]: https://sonarcloud.io/api/project_badges/measure?project=aosedge_aos_core_lib_cpp&metric=alert_status&branch=develop
-[qg-dev-link]: https://sonarcloud.io/summary/new_code?id=aosedge_aos_core_lib_cpp&branch=develop
 
 # AosCore cpp libraries
 


### PR DESCRIPTION
Drop the develop-branch row from the CI/coverage/quality-gate badge table and keep a single set of badges for main.