### PR TITLE
ci: simplify README badges to develop branch only

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,8 @@
 <!-- markdownlint-disable-next-line MD041 -->
-| Branch | CI | Coverage | Quality Gate |
-|--------|----|----------|--------------|
-| main | [![ci][ci-main]][ci-main-link] | [![coverage][cov-main]][cov-main-link] | [![Quality Gate][qg-main]][qg-main-link] |
-| develop | [![ci][ci-dev]][ci-dev-link] | [![coverage][cov-dev]][cov-dev-link] | [![Quality Gate][qg-dev]][qg-dev-link] |
+[![ci][ci-dev]][ci-dev-link]
+[![coverage][cov-dev]][cov-dev-link]
+[![Quality Gate][qg-dev]][qg-dev-link]
 
-[ci-main]: https://github.com/aosedge/aos_core_lib_cpp/actions/workflows/build-test.yaml/badge.svg?branch=main
-[ci-main-link]: https://github.com/aosedge/aos_core_lib_cpp/actions/workflows/build-test.yaml?query=branch%3Amain
-[cov-main]: https://sonarcloud.io/api/project_badges/measure?project=aosedge_aos_core_lib_cpp&metric=coverage&branch=main
-[cov-main-link]: https://sonarcloud.io/summary/new_code?id=aosedge_aos_core_lib_cpp&branch=main
-[qg-main]: https://sonarcloud.io/api/project_badges/measure?project=aosedge_aos_core_lib_cpp&metric=alert_status&branch=main
-[qg-main-link]: https://sonarcloud.io/summary/new_code?id=aosedge_aos_core_lib_cpp&branch=main
 [ci-dev]: https://github.com/aosedge/aos_core_lib_cpp/actions/workflows/build-test.yaml/badge.svg?branch=develop
 [ci-dev-link]: https://github.com/aosedge/aos_core_lib_cpp/actions/workflows/build-test.yaml?query=branch%3Adevelop
 [cov-dev]: https://sonarcloud.io/api/project_badges/measure?project=aosedge_aos_core_lib_cpp&metric=coverage&branch=develop


### PR DESCRIPTION
Drop the main-branch row from the CI/coverage/quality-gate badge table and keep a single set of badges for develop.