### PR TITLE
ci: use pull_request instead of pull_request_target

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -8,7 +8,7 @@ on:
       - feature*
       - release*
 
-  pull_request_target:
+  pull_request:
     types:
       - edited
       - opened
@@ -38,8 +38,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          ref: ${{github.event.pull_request.head.ref}}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
           fetch-depth: 0
 
       - name: Install build wrapper
@@ -72,7 +70,7 @@ jobs:
             --define "sonar.coverageReportPaths=build/coverage_sonarqube.xml"
 
       - name: SonarQube analysis (on pull request)
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request'
         uses: SonarSource/sonarqube-scan-action@v7
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
ci: Fixes fork PR checkout security error and eliminates duplicate CI runs