### PR TITLE
ci: use pull_request trigger and skip SonarQube for fork PRs

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -63,25 +63,29 @@ jobs:
         uses: SonarSource/sonarqube-scan-action@v7
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-
         with:
           args: >
             --define "sonar.cfamily.compile-commands=${{ env.BUILD_WRAPPER_OUT_DIR }}/compile_commands.json"
             --define "sonar.coverageReportPaths=build/coverage_sonarqube.xml"
 
-      - name: SonarQube analysis (on pull request)
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-        uses: SonarSource/sonarqube-scan-action@v7
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Save PR metadata
+        if: github.event_name == 'pull_request'
+        run: |
+          mkdir -p ./sonar-pr-info
+          echo "${{ github.event.pull_request.number }}" > ./sonar-pr-info/pr_number
+          echo "${{ github.event.pull_request.head.sha }}" > ./sonar-pr-info/pr_head_sha
+          echo "${{ github.event.pull_request.head.ref }}" > ./sonar-pr-info/pr_head_ref
+          echo "${{ github.event.pull_request.base.ref }}" > ./sonar-pr-info/pr_base_ref
 
+      - name: Upload SonarQube artifacts
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
         with:
-          projectBaseDir: "."
-          args: >
-            --define "sonar.scm.revision=${{ github.event.pull_request.head.sha }}"
-            --define "sonar.pullrequest.key=${{ github.event.pull_request.number }}"
-            --define "sonar.pullrequest.branch=${{ github.event.pull_request.head.ref }}"
-            --define "sonar.pullrequest.base=${{ github.event.pull_request.base.ref }}"
-            --define "sonar.cfamily.compile-commands=${{ env.BUILD_WRAPPER_OUT_DIR }}/compile_commands.json"
-            --define "sonar.coverageReportPaths=build/coverage_sonarqube.xml"
+          name: sonar-data
+          path: |
+            build_wrapper_output_directory/
+            build/coverage_sonarqube.xml
+            sonar-pr-info/
+            sonar-project.properties
+            src/
+          retention-days: 1

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -70,7 +70,7 @@ jobs:
             --define "sonar.coverageReportPaths=build/coverage_sonarqube.xml"
 
       - name: SonarQube analysis (on pull request)
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: SonarSource/sonarqube-scan-action@v7
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -1,0 +1,48 @@
+name: SonarQube analysis (on pull request)
+
+on:
+  workflow_run:
+    workflows: ["Build (Debug) and test"]
+    types:
+      - completed
+
+jobs:
+  sonar:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
+    permissions:
+      pull-requests: read
+      actions: read
+
+    steps:
+      - name: Download SonarQube artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: sonar-data
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read PR metadata
+        id: pr
+        run: |
+          echo "number=$(cat sonar-pr-info/pr_number)" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$(cat sonar-pr-info/pr_head_sha)" >> "$GITHUB_OUTPUT"
+          echo "head_ref=$(cat sonar-pr-info/pr_head_ref)" >> "$GITHUB_OUTPUT"
+          echo "base_ref=$(cat sonar-pr-info/pr_base_ref)" >> "$GITHUB_OUTPUT"
+
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v7
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          projectBaseDir: "."
+          args: >
+            --define "sonar.scm.revision=${{ steps.pr.outputs.head_sha }}"
+            --define "sonar.pullrequest.key=${{ steps.pr.outputs.number }}"
+            --define "sonar.pullrequest.branch=${{ steps.pr.outputs.head_ref }}"
+            --define "sonar.pullrequest.base=${{ steps.pr.outputs.base_ref }}"
+            --define "sonar.cfamily.compile-commands=build_wrapper_output_directory/compile_commands.json"
+            --define "sonar.coverageReportPaths=build/coverage_sonarqube.xml"


### PR DESCRIPTION
## Changes

- Switched from `pull_request_target` to `pull_request` for security (no longer executes untrusted fork code with elevated privileges)
- Skip SonarQube analysis step for fork PRs since `SONAR_TOKEN` is not available in that context
- Internal PRs (same repo) still get full SonarQube PR decoration
- Fork PRs get analyzed on push to main after merge

## Why

`pull_request_target` runs in the base repo context with access to secrets, but also builds and executes code from the PR — this is a security risk for public repos accepting contributions from forks.

With `pull_request`, secrets are not exposed to fork PRs by design. SonarQube requires `SONAR_TOKEN` to function, so the analysis step is skipped for fork PRs via:

```yaml
if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
```