### PR TITLE
ci: split SonarQube into workflow_run for secure fork PR analysis

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -69,19 +69,24 @@ jobs:
             --define "sonar.cfamily.compile-commands=${{ env.BUILD_WRAPPER_OUT_DIR }}/compile_commands.json"
             --define "sonar.coverageReportPaths=build/coverage_sonarqube.xml"
 
-      - name: SonarQube analysis (on pull request)
+      - name: Save PR metadata
         if: github.event_name == 'pull_request'
-        uses: SonarSource/sonarqube-scan-action@v7
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p ./sonar-pr-info
+          echo "${{ github.event.pull_request.number }}" > ./sonar-pr-info/pr_number
+          echo "${{ github.event.pull_request.head.sha }}" > ./sonar-pr-info/pr_head_sha
+          echo "${{ github.event.pull_request.head.ref }}" > ./sonar-pr-info/pr_head_ref
+          echo "${{ github.event.pull_request.base.ref }}" > ./sonar-pr-info/pr_base_ref
 
+      - name: Upload SonarQube artifacts
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
         with:
-          projectBaseDir: "."
-          args: >
-            --define "sonar.scm.revision=${{ github.event.pull_request.head.sha }}"
-            --define "sonar.pullrequest.key=${{ github.event.pull_request.number }}"
-            --define "sonar.pullrequest.branch=${{ github.event.pull_request.head.ref }}"
-            --define "sonar.pullrequest.base=${{ github.event.pull_request.base.ref }}"
-            --define "sonar.cfamily.compile-commands=${{ env.BUILD_WRAPPER_OUT_DIR }}/compile_commands.json"
-            --define "sonar.coverageReportPaths=build/coverage_sonarqube.xml"
+          name: sonar-data
+          path: |
+            build_wrapper_output_directory/
+            build/coverage_sonarqube.xml
+            sonar-pr-info/
+            sonar-project.properties
+            src/
+          retention-days: 1

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -1,0 +1,48 @@
+name: SonarQube analysis (on pull request)
+
+on:
+  workflow_run:
+    workflows: ["Build (Debug) and test"]
+    types:
+      - completed
+
+jobs:
+  sonar:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
+    permissions:
+      pull-requests: read
+      actions: read
+
+    steps:
+      - name: Download SonarQube artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: sonar-data
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read PR metadata
+        id: pr
+        run: |
+          echo "number=$(cat sonar-pr-info/pr_number)" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$(cat sonar-pr-info/pr_head_sha)" >> "$GITHUB_OUTPUT"
+          echo "head_ref=$(cat sonar-pr-info/pr_head_ref)" >> "$GITHUB_OUTPUT"
+          echo "base_ref=$(cat sonar-pr-info/pr_base_ref)" >> "$GITHUB_OUTPUT"
+
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v7
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          projectBaseDir: "."
+          args: >
+            --define "sonar.scm.revision=${{ steps.pr.outputs.head_sha }}"
+            --define "sonar.pullrequest.key=${{ steps.pr.outputs.number }}"
+            --define "sonar.pullrequest.branch=${{ steps.pr.outputs.head_ref }}"
+            --define "sonar.pullrequest.base=${{ steps.pr.outputs.base_ref }}"
+            --define "sonar.cfamily.compile-commands=build_wrapper_output_directory/compile_commands.json"
+            --define "sonar.coverageReportPaths=build/coverage_sonarqube.xml"


### PR DESCRIPTION
## Changes

- Removed inline SonarQube PR analysis step (fork PRs had no access to `SONAR_TOKEN`)
- Build workflow now uploads compile-commands + coverage as artifacts for PR events
- New `sonar.yaml` workflow triggers via `workflow_run` after build succeeds, downloads artifacts, and runs SonarQube with secrets in the base repo context

## Why

`pull_request` events don't expose secrets to fork PRs (GitHub security feature). By splitting SonarQube into a `workflow_run`-triggered workflow, fork PRs get full Sonar analysis and PR decoration without ever executing untrusted code with secrets access.

## How it works

1. Fork PR opened → `build-test.yaml` runs (build + test + upload artifacts)
2. Build succeeds → `sonar.yaml` triggers via `workflow_run`
3. Sonar workflow downloads artifacts, runs scanner with `SONAR_TOKEN`
4. PR gets quality gate decoration