### PR TITLE
ci: allow unsafe checkout of fork PR head in build-test

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -41,6 +41,7 @@ jobs:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
           fetch-depth: 0
+          allow-unsafe-pr-checkout: true
 
       - name: Install build wrapper
         uses: SonarSource/sonarqube-scan-action/install-build-wrapper@v7


### PR DESCRIPTION
pull_request_target checks out the PR head ref/repo directly, which actions/checkout now refuses by default since it can run untrusted fork code with elevated workflow permissions. Explicitly opt in since this checkout is required for the build/test/SonarQube steps.