### PR TITLE
cm: imagemanager: allocate remaining size for partial downloads

### DIFF
--- a/src/core/cm/imagemanager/imagemanager.cpp
+++ b/src/core/cm/imagemanager/imagemanager.cpp
@@ -55,10 +55,6 @@ Error ImageManager::Init(AllocatorItf& allocator, const Config& config, StorageI
         return AOS_ERROR_WRAP(err);
     }
 
-    if (auto err = AllocateSpaceForPartialDownloads(); !err.IsNone()) {
-        return AOS_ERROR_WRAP(err);
-    }
-
     RegisterOutdatedItems(*items);
 
     auto [cleanupSize, cleanupErr] = CleanupOrphanedBlobs();
@@ -571,54 +567,6 @@ Error ImageManager::WaitForStop()
     return ErrorEnum::eNone;
 }
 
-Error ImageManager::AllocateSpaceForPartialDownloads()
-{
-    LOG_DBG() << "Allocate space for partial downloads" << Log::Field("path", mBlobsDownloadPath);
-
-    auto algorithmDirIterator = fs::DirIterator(mBlobsDownloadPath);
-
-    while (algorithmDirIterator.Next()) {
-        auto algorithm    = algorithmDirIterator->mPath;
-        auto algorithmDir = fs::JoinPath(mBlobsDownloadPath, algorithm);
-
-        auto fileIterator = fs::DirIterator(algorithmDir);
-
-        while (fileIterator.Next()) {
-            auto fileName = fileIterator->mPath;
-            auto filePath = fs::JoinPath(algorithmDir, fileName);
-
-            auto [fileSize, sizeErr] = fs::CalculateSize(*mAllocator, filePath);
-            if (!sizeErr.IsNone()) {
-                LOG_WRN() << "Failed to get size for partial download" << Log::Field("path", filePath)
-                          << Log::Field(sizeErr);
-
-                continue;
-            }
-
-            if (fileSize == 0) {
-                continue;
-            }
-
-            UniquePtr<spaceallocator::SpaceItf> space;
-            Error                               err;
-
-            if (Tie(space, err) = mDownloadingSpaceAllocator->AllocateSpace(fileSize); !err.IsNone()) {
-                LOG_ERR() << "Failed to allocate space for partial download" << Log::Field("path", filePath)
-                          << Log::Field("size", fileSize) << Log::Field(err);
-
-                return AOS_ERROR_WRAP(err);
-            }
-
-            space->Accept();
-
-            LOG_DBG() << "Allocated space for partial download" << Log::Field("path", filePath)
-                      << Log::Field("size", fileSize);
-        }
-    }
-
-    return ErrorEnum::eNone;
-}
-
 Error ImageManager::RemovePendingItems(const Array<ItemInfo>& storedItems, Array<UpdateItemStatus>& statuses)
 {
     LOG_DBG() << "Remove pending items";
@@ -1086,10 +1034,13 @@ Error ImageManager::EnsureBlob(const String& digest, const String& downloadPath,
         return AOS_ERROR_WRAP(ErrorEnum::eNoMemory);
     }
 
-    UniquePtr<spaceallocator::SpaceItf> downloadingSpace;
+    DownloadSpace downloadSpace;
+
+    auto discardDownload
+        = DeferRelease(&downloadSpace, [&](DownloadSpace* spacePtr) { DiscardDownload(downloadPath, *spacePtr); });
 
     do {
-        if (auto err = DownloadBlob(digest, downloadPath, installPath, *blobInfo, downloadingSpace); !err.IsNone()) {
+        if (auto err = DownloadBlob(digest, downloadPath, installPath, *blobInfo, downloadSpace); !err.IsNone()) {
             if (err == ErrorEnum::eAlreadyExist) {
                 return ErrorEnum::eNone;
             }
@@ -1101,8 +1052,6 @@ Error ImageManager::EnsureBlob(const String& digest, const String& downloadPath,
 
         if (auto err = mFileInfoProvider->GetFileInfo(downloadPath, downloadFileInfo, crypto::HashEnum::eSHA3_256);
             !err.IsNone()) {
-            downloadingSpace->Release();
-
             return AOS_ERROR_WRAP(err);
         }
 
@@ -1112,20 +1061,12 @@ Error ImageManager::EnsureBlob(const String& digest, const String& downloadPath,
 
         LOG_WRN() << "Download checksum mismatch, retrying download" << Log::Field("digest", digest);
 
-        downloadingSpace->Release();
-
-        if (auto removeErr = fs::RemoveAll(downloadPath); !removeErr.IsNone()) {
-            LOG_ERR() << "Failed to remove download path" << Log::Field("path", downloadPath) << Log::Field(removeErr);
-        }
+        DiscardDownload(downloadPath, downloadSpace);
     } while (true);
 
     auto err = DecryptAndValidateBlob(downloadPath, installPath, *blobInfo, certificates, certificateChains, space);
 
-    downloadingSpace->Release();
-
-    if (auto removeErr = fs::RemoveAll(downloadPath); !removeErr.IsNone()) {
-        LOG_ERR() << "Failed to remove download path" << Log::Field("path", downloadPath) << Log::Field(removeErr);
-    }
+    DiscardDownload(downloadPath, downloadSpace);
 
     return AOS_ERROR_WRAP(err);
 }
@@ -1217,39 +1158,90 @@ Error ImageManager::CheckExistingBlob(const String& installPath)
     return ErrorEnum::eNone;
 }
 
-Error ImageManager::PrepareDownloadSpace(const String& downloadPath, const BlobInfo& blobInfo,
-    size_t& partialDownloadSize, UniquePtr<spaceallocator::SpaceItf>& downloadingSpace)
+Error ImageManager::PrepareDownloadSpace(
+    const String& downloadPath, const BlobInfo& blobInfo, DownloadSpace& downloadSpace)
 {
+    downloadSpace.mExistingSize = 0;
+    downloadSpace.mTotalSize    = blobInfo.mSize;
+
     auto [downloadExists, checkDownloadErr] = fs::FileExist(downloadPath);
     if (!checkDownloadErr.IsNone()) {
         return AOS_ERROR_WRAP(checkDownloadErr);
     }
 
-    partialDownloadSize = 0;
-
     if (downloadExists) {
-        auto [dirSize, getSizeErr] = fs::CalculateSize(*mAllocator, downloadPath);
+        auto [partialSize, getSizeErr] = fs::CalculateSize(*mAllocator, downloadPath);
         if (!getSizeErr.IsNone()) {
             return AOS_ERROR_WRAP(getSizeErr);
         }
 
-        partialDownloadSize = dirSize;
-    }
+        if (partialSize > blobInfo.mSize) {
+            LOG_WRN() << "Partial download exceeds blob size, removing" << Log::Field("path", downloadPath)
+                      << Log::Field("size", partialSize) << Log::Field("blobSize", blobInfo.mSize);
 
-    mDownloadingSpaceAllocator->FreeSpace(partialDownloadSize);
+            if (auto err = fs::RemoveAll(downloadPath); !err.IsNone()) {
+                return AOS_ERROR_WRAP(err);
+            }
+        } else {
+            downloadSpace.mExistingSize = partialSize;
+        }
+    }
 
     Error err;
 
-    Tie(downloadingSpace, err) = mDownloadingSpaceAllocator->AllocateSpace(blobInfo.mSize);
+    Tie(downloadSpace.mSpace, err)
+        = mDownloadingSpaceAllocator->AllocateSpace(blobInfo.mSize - downloadSpace.mExistingSize);
     if (!err.IsNone()) {
         return AOS_ERROR_WRAP(err);
     }
 
+    LOG_DBG() << "Prepared download space" << Log::Field("path", downloadPath)
+              << Log::Field("existingSize", downloadSpace.mExistingSize) << Log::Field("blobSize", blobInfo.mSize);
+
     return ErrorEnum::eNone;
 }
 
-Error ImageManager::PerformDownload(const BlobInfo& blobInfo, const String& downloadPath, size_t partialDownloadSize,
-    UniquePtr<spaceallocator::SpaceItf>& downloadingSpace)
+void ImageManager::DiscardDownload(const String& downloadPath, DownloadSpace& downloadSpace)
+{
+    if (!downloadSpace.mSpace) {
+        return;
+    }
+
+    if (auto err = fs::RemoveAll(downloadPath); !err.IsNone()) {
+        LOG_ERR() << "Failed to remove download path" << Log::Field("path", downloadPath) << Log::Field(err);
+    }
+
+    if (downloadSpace.mExistingSize != 0) {
+        mDownloadingSpaceAllocator->FreeSpace(downloadSpace.mExistingSize);
+    }
+
+    if (auto err = downloadSpace.mSpace->Release(); !err.IsNone()) {
+        LOG_ERR() << "Failed to release downloading space" << Log::Field(err);
+    }
+
+    downloadSpace.mSpace.Reset();
+    downloadSpace.mExistingSize = 0;
+}
+
+void ImageManager::AcceptDownloadSpace(DownloadSpace& downloadSpace, size_t bytesOnDisk)
+{
+    if (!downloadSpace.mSpace) {
+        return;
+    }
+
+    if (bytesOnDisk < downloadSpace.mTotalSize) {
+        mDownloadingSpaceAllocator->FreeSpace(downloadSpace.mTotalSize - bytesOnDisk);
+    }
+
+    if (auto err = downloadSpace.mSpace->Accept(); !err.IsNone()) {
+        LOG_ERR() << "Failed to accept downloading space" << Log::Field(err);
+    }
+
+    downloadSpace.mSpace.Reset();
+    downloadSpace.mExistingSize = 0;
+}
+
+Error ImageManager::PerformDownload(const BlobInfo& blobInfo, const String& downloadPath, DownloadSpace& downloadSpace)
 {
     {
         LockGuard lock {mMutex};
@@ -1263,16 +1255,6 @@ Error ImageManager::PerformDownload(const BlobInfo& blobInfo, const String& down
         mCurrentDownloadDigest.Clear();
     });
 
-    StaticString<cFilePathLen> downloadDir;
-
-    if (auto err = fs::ParentPath(downloadPath, downloadDir); !err.IsNone()) {
-        return AOS_ERROR_WRAP(err);
-    }
-
-    if (auto err = fs::MakeDirAll(downloadDir); !err.IsNone()) {
-        return AOS_ERROR_WRAP(err);
-    }
-
     while (true) {
         auto err = mDownloader->Download(blobInfo.mDigest, blobInfo.mURLs[0], downloadPath);
         if (!err.IsNone()) {
@@ -1280,27 +1262,15 @@ Error ImageManager::PerformDownload(const BlobInfo& blobInfo, const String& down
                       << Log::Field("path", downloadPath) << Log::Field(AOS_ERROR_WRAP(err));
 
             if (err = WaitForStop(); !err.IsNone()) {
-                auto [newPartialSize, retrySizeErr] = fs::CalculateSize(*mAllocator, downloadPath);
-                if (!retrySizeErr.IsNone()) {
+                auto [bytesOnDisk, sizeErr] = fs::CalculateSize(*mAllocator, downloadPath);
+                if (!sizeErr.IsNone()) {
                     LOG_WRN() << "Failed to get partial download size" << Log::Field("path", downloadPath)
-                              << Log::Field(retrySizeErr);
-
-                    downloadingSpace->Release();
+                              << Log::Field(sizeErr);
 
                     return err;
                 }
 
-                downloadingSpace->Release();
-
-                Error allocationErr;
-
-                Tie(downloadingSpace, allocationErr)
-                    = mDownloadingSpaceAllocator->AllocateSpace(newPartialSize - partialDownloadSize);
-                if (!allocationErr.IsNone()) {
-                    return AOS_ERROR_WRAP(allocationErr);
-                }
-
-                downloadingSpace->Accept();
+                AcceptDownloadSpace(downloadSpace, bytesOnDisk);
 
                 return err;
             }
@@ -1320,7 +1290,7 @@ Error ImageManager::PerformDownload(const BlobInfo& blobInfo, const String& down
 }
 
 Error ImageManager::DownloadBlob(const String& digest, const String& downloadPath, const String& installPath,
-    BlobInfo& blobInfo, UniquePtr<spaceallocator::SpaceItf>& downloadingSpace)
+    BlobInfo& blobInfo, DownloadSpace& downloadSpace)
 {
     LOG_DBG() << "Download blob" << Log::Field("digest", digest);
 
@@ -1340,13 +1310,21 @@ Error ImageManager::DownloadBlob(const String& digest, const String& downloadPat
         return AOS_ERROR_WRAP(err);
     }
 
-    size_t partialDownloadSize = 0;
+    StaticString<cFilePathLen> downloadDir;
 
-    if (auto err = PrepareDownloadSpace(downloadPath, blobInfo, partialDownloadSize, downloadingSpace); !err.IsNone()) {
+    if (auto err = fs::ParentPath(downloadPath, downloadDir); !err.IsNone()) {
         return AOS_ERROR_WRAP(err);
     }
 
-    if (auto err = PerformDownload(blobInfo, downloadPath, partialDownloadSize, downloadingSpace); !err.IsNone()) {
+    if (auto err = fs::MakeDirAll(downloadDir); !err.IsNone()) {
+        return AOS_ERROR_WRAP(err);
+    }
+
+    if (auto err = PrepareDownloadSpace(downloadPath, blobInfo, downloadSpace); !err.IsNone()) {
+        return AOS_ERROR_WRAP(err);
+    }
+
+    if (auto err = PerformDownload(blobInfo, downloadPath, downloadSpace); !err.IsNone()) {
         return AOS_ERROR_WRAP(err);
     }
 

--- a/src/core/cm/imagemanager/imagemanager.hpp
+++ b/src/core/cm/imagemanager/imagemanager.hpp
@@ -176,9 +176,17 @@ private:
     static constexpr auto cRetryTimeout       = Time::cSeconds * 2;
     static constexpr auto cDigestAlgorithmLen = 16;
 
+    /**
+     * Downloading space of a single blob. mSpace reserves only bytes to be written: mTotalSize - mExistingSize.
+     */
+    struct DownloadSpace {
+        UniquePtr<spaceallocator::SpaceItf> mSpace;
+        size_t                              mExistingSize {};
+        size_t                              mTotalSize {};
+    };
+
     Error RemoveOutdatedItems();
     Error WaitForStop();
-    Error AllocateSpaceForPartialDownloads();
     Error RemovePendingItems(const Array<ItemInfo>& storedItems, Array<UpdateItemStatus>& statuses);
     Error CleanupDownloadingItems(const Array<UpdateItemInfo>& currentItems, const Array<ItemInfo>& storedItems);
     Error VerifyStoredItems(const Array<UpdateItemInfo>& itemsInfo, Array<ItemInfo>& storedItems,
@@ -208,13 +216,13 @@ private:
         const Array<crypto::CertificateInfo>&      certificates,
         const Array<crypto::CertificateChainInfo>& certificateChains, UniquePtr<spaceallocator::SpaceItf>& space);
     Error DownloadBlob(const String& digest, const String& downloadPath, const String& installPath, BlobInfo& blobInfo,
-        UniquePtr<spaceallocator::SpaceItf>& downloadingSpace);
+        DownloadSpace& downloadSpace);
     Error GetBlobInfo(const String& digest, BlobInfo& blobInfo);
     Error CheckExistingBlob(const String& installPath);
-    Error PrepareDownloadSpace(const String& downloadPath, const BlobInfo& blobInfo, size_t& partialDownloadSize,
-        UniquePtr<spaceallocator::SpaceItf>& downloadingSpace);
-    Error PerformDownload(const BlobInfo& blobInfo, const String& downloadPath, size_t partialDownloadSize,
-        UniquePtr<spaceallocator::SpaceItf>& downloadingSpace);
+    Error PrepareDownloadSpace(const String& downloadPath, const BlobInfo& blobInfo, DownloadSpace& downloadSpace);
+    Error PerformDownload(const BlobInfo& blobInfo, const String& downloadPath, DownloadSpace& downloadSpace);
+    void  DiscardDownload(const String& downloadPath, DownloadSpace& downloadSpace);
+    void  AcceptDownloadSpace(DownloadSpace& downloadSpace, size_t bytesOnDisk);
     Error DecryptAndValidateBlob(const String& downloadPath, const String& installPath, const BlobInfo& blobInfo,
         const Array<crypto::CertificateInfo>&      certificates,
         const Array<crypto::CertificateChainInfo>& certificateChains,

--- a/src/core/cm/imagemanager/tests/imagemanager.cpp
+++ b/src/core/cm/imagemanager/tests/imagemanager.cpp
@@ -63,6 +63,94 @@ protected:
         fs::RemoveAll(mConfig.mDownloadPath);
     }
 
+    static constexpr auto cBlobDigest = "sha256:000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+    static constexpr auto cBlobHash   = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+
+    StaticString<cFilePathLen> GetBlobDownloadPath() const
+    {
+        return fs::JoinPath(fs::JoinPath(mConfig.mDownloadPath, "blobs/sha256"), cBlobHash);
+    }
+
+    static void CreateFile(const String& path, size_t size)
+    {
+        StaticString<cFilePathLen> dir;
+
+        ASSERT_TRUE(fs::ParentPath(path, dir).IsNone());
+        ASSERT_TRUE(fs::MakeDirAll(dir).IsNone());
+
+        std::ofstream file(path.CStr(), std::ios::binary | std::ios::trunc);
+        ASSERT_TRUE(file.is_open());
+
+        if (size > 0) {
+            file.seekp(static_cast<std::streamoff>(size) - 1);
+            file.put('\0');
+        }
+    }
+
+    void ExpectSingleBlobItem(size_t blobSize, int getAllItemsCalls)
+    {
+        EXPECT_CALL(mStorageMock, GetAllItemsInfos(_)).Times(getAllItemsCalls).WillRepeatedly(Return(ErrorEnum::eNone));
+        EXPECT_CALL(mStorageMock, AddItem(_)).WillOnce(Return(ErrorEnum::eNone));
+
+        EXPECT_CALL(mBlobInfoProviderMock, GetBlobsInfos(_, _))
+            .WillOnce(Invoke([blobSize](const auto& digests, Array<BlobInfo>& blobsInfo) {
+                BlobInfo info;
+                info.mDigest = digests[0];
+                info.mSize   = blobSize;
+                info.mURLs.PushBack("http://test.com/blob");
+                info.mDecryptInfo.EmplaceValue();
+                info.mSignInfo.EmplaceValue();
+
+                for (size_t i = 0; i < crypto::cSHA256Size; i++) {
+                    info.mSHA256.PushBack(static_cast<uint8_t>(i));
+                }
+
+                blobsInfo.PushBack(info);
+
+                return ErrorEnum::eNone;
+            }));
+    }
+
+    void ExpectBlobChecksum(int times)
+    {
+        EXPECT_CALL(mFileInfoProviderMock, GetFileInfo(_, _, _))
+            .Times(times)
+            .WillRepeatedly(Invoke([](const String&, fs::FileInfo& info, crypto::Hash) {
+                for (size_t i = 0; i < crypto::cSHA256Size; i++) {
+                    info.mCheckSum.PushBack(static_cast<uint8_t>(i));
+                }
+
+                return ErrorEnum::eNone;
+            }));
+    }
+
+    RetWithError<UniquePtr<spaceallocator::SpaceItf>> MakeSpaceMock(int acceptTimes, int releaseTimes)
+    {
+        auto space = MakeUnique<spaceallocator::SpaceMock>(&mAllocator);
+        EXPECT_TRUE(space);
+
+        EXPECT_CALL(*space, Accept()).Times(acceptTimes);
+        EXPECT_CALL(*space, Release()).Times(releaseTimes);
+
+        return {std::move(space), ErrorEnum::eNone};
+    }
+
+    void ExpectFileRemoved(const String& path) const
+    {
+        auto [exists, err] = fs::FileExist(path);
+
+        EXPECT_TRUE(err.IsNone());
+        EXPECT_FALSE(exists);
+    }
+
+    void ExpectFileSize(const String& path, size_t size)
+    {
+        auto [fileSize, err] = fs::CalculateSize(mAllocator, path);
+
+        EXPECT_TRUE(err.IsNone());
+        EXPECT_EQ(fileSize, size);
+    }
+
     // mAllocator must be declared (and therefore destroyed) after any member that allocates from it, since
     // members are destroyed in reverse declaration order.
     HeapAllocator mAllocator;
@@ -712,6 +800,297 @@ TEST_F(ImageManagerTest, DownloadUpdateItems_Cancel_DownloadFailed)
     EXPECT_TRUE(cancelErr.IsNone());
 
     downloadThread.join();
+}
+
+TEST_F(ImageManagerTest, DownloadUpdateItems_PartialDownload_AllocatesRemainingSize)
+{
+    constexpr size_t cBlobSize    = 1024;
+    constexpr size_t cPartialSize = 600;
+
+    StaticArray<UpdateItemInfo, 5>               itemsInfo;
+    StaticArray<crypto::CertificateInfo, 1>      certificates;
+    StaticArray<crypto::CertificateChainInfo, 1> certificateChains;
+    StaticArray<UpdateItemStatus, 5>             statuses;
+
+    UpdateItemInfo item;
+    item.mItemID      = "service1";
+    item.mType        = UpdateItemTypeEnum::eService;
+    item.mVersion     = "1.0.0";
+    item.mIndexDigest = cBlobDigest;
+    itemsInfo.PushBack(item);
+
+    CreateFile(GetBlobDownloadPath(), cPartialSize);
+
+    ExpectSingleBlobItem(cBlobSize, 3);
+
+    EXPECT_CALL(mDownloadingSpaceAllocatorMock, AllocateSpace(cBlobSize - cPartialSize))
+        .WillOnce(Invoke([this](size_t) { return MakeSpaceMock(0, 1); }));
+
+    EXPECT_CALL(mDownloadingSpaceAllocatorMock, FreeSpace(cPartialSize)).Times(1);
+
+    EXPECT_CALL(mInstallSpaceAllocatorMock, AllocateSpace(cBlobSize)).WillOnce(Invoke([this](size_t) {
+        return MakeSpaceMock(1, 0);
+    }));
+
+    EXPECT_CALL(mDownloaderMock, Download(_, _, _)).WillOnce(Return(ErrorEnum::eNone));
+
+    ExpectBlobChecksum(2);
+
+    EXPECT_CALL(mCryptoHelperMock, Decrypt(_, _, _)).WillOnce(Return(ErrorEnum::eNone));
+    EXPECT_CALL(mCryptoHelperMock, ValidateSigns(_, _, _, _)).WillOnce(Return(ErrorEnum::eNone));
+
+    EXPECT_CALL(mOCISpecMock, LoadImageIndex(_, _)).WillOnce(Return(ErrorEnum::eNone));
+
+    EXPECT_CALL(mStorageMock, UpdateItemState(_, _, ItemState(ItemStateEnum::ePending), _))
+        .WillOnce(Return(ErrorEnum::eNone));
+
+    auto err = mImageManager.DownloadUpdateItems(itemsInfo, certificates, certificateChains, statuses);
+
+    EXPECT_TRUE(err.IsNone());
+    ASSERT_EQ(statuses.Size(), 1);
+    EXPECT_EQ(statuses[0].mState, ItemStateEnum::ePending);
+
+    ExpectFileRemoved(GetBlobDownloadPath());
+}
+
+TEST_F(ImageManagerTest, DownloadUpdateItems_PartialDownloadExceedsBlobSize_Redownloads)
+{
+    constexpr size_t cBlobSize    = 1024;
+    constexpr size_t cPartialSize = 2048;
+
+    StaticArray<UpdateItemInfo, 5>               itemsInfo;
+    StaticArray<crypto::CertificateInfo, 1>      certificates;
+    StaticArray<crypto::CertificateChainInfo, 1> certificateChains;
+    StaticArray<UpdateItemStatus, 5>             statuses;
+
+    UpdateItemInfo item;
+    item.mItemID      = "service1";
+    item.mType        = UpdateItemTypeEnum::eService;
+    item.mVersion     = "1.0.0";
+    item.mIndexDigest = cBlobDigest;
+    itemsInfo.PushBack(item);
+
+    CreateFile(GetBlobDownloadPath(), cPartialSize);
+
+    ExpectSingleBlobItem(cBlobSize, 3);
+
+    EXPECT_CALL(mDownloadingSpaceAllocatorMock, AllocateSpace(cBlobSize)).WillOnce(Invoke([this](size_t) {
+        return MakeSpaceMock(0, 1);
+    }));
+
+    EXPECT_CALL(mDownloadingSpaceAllocatorMock, FreeSpace(_)).Times(0);
+
+    EXPECT_CALL(mInstallSpaceAllocatorMock, AllocateSpace(cBlobSize)).WillOnce(Invoke([this](size_t) {
+        return MakeSpaceMock(1, 0);
+    }));
+
+    EXPECT_CALL(mDownloaderMock, Download(_, _, _)).WillOnce(Return(ErrorEnum::eNone));
+
+    ExpectBlobChecksum(2);
+
+    EXPECT_CALL(mCryptoHelperMock, Decrypt(_, _, _)).WillOnce(Return(ErrorEnum::eNone));
+    EXPECT_CALL(mCryptoHelperMock, ValidateSigns(_, _, _, _)).WillOnce(Return(ErrorEnum::eNone));
+
+    EXPECT_CALL(mOCISpecMock, LoadImageIndex(_, _)).WillOnce(Return(ErrorEnum::eNone));
+
+    EXPECT_CALL(mStorageMock, UpdateItemState(_, _, ItemState(ItemStateEnum::ePending), _))
+        .WillOnce(Return(ErrorEnum::eNone));
+
+    auto err = mImageManager.DownloadUpdateItems(itemsInfo, certificates, certificateChains, statuses);
+
+    EXPECT_TRUE(err.IsNone());
+    ASSERT_EQ(statuses.Size(), 1);
+    EXPECT_EQ(statuses[0].mState, ItemStateEnum::ePending);
+
+    ExpectFileRemoved(GetBlobDownloadPath());
+}
+
+TEST_F(ImageManagerTest, DownloadUpdateItems_Cancel_KeepsPartialDownloadAccounted)
+{
+    constexpr size_t cBlobSize       = 1024;
+    constexpr size_t cDownloadedSize = 700;
+
+    StaticArray<UpdateItemInfo, 5>               itemsInfo;
+    StaticArray<crypto::CertificateInfo, 1>      certificates;
+    StaticArray<crypto::CertificateChainInfo, 1> certificateChains;
+    StaticArray<UpdateItemStatus, 5>             statuses;
+
+    UpdateItemInfo item;
+    item.mItemID      = "service1";
+    item.mVersion     = "1.0.0";
+    item.mIndexDigest = cBlobDigest;
+    itemsInfo.PushBack(item);
+
+    ExpectSingleBlobItem(cBlobSize, 2);
+
+    EXPECT_CALL(mDownloadingSpaceAllocatorMock, AllocateSpace(cBlobSize)).WillOnce(Invoke([this](size_t) {
+        return MakeSpaceMock(1, 0);
+    }));
+
+    EXPECT_CALL(mDownloadingSpaceAllocatorMock, FreeSpace(cBlobSize - cDownloadedSize)).Times(1);
+
+    EXPECT_CALL(mDownloaderMock, Download(_, _, _))
+        .WillOnce(Invoke([](const String&, const String&, const String& path) {
+            CreateFile(path, cDownloadedSize);
+
+            return ErrorEnum::eRuntime;
+        }));
+
+    EXPECT_CALL(mDownloaderMock, Cancel(_)).WillOnce(Return(ErrorEnum::eNone));
+
+    EXPECT_CALL(mStorageMock, UpdateItemState(_, _, _, _)).Times(AtLeast(0));
+
+    std::thread downloadThread([&]() {
+        auto err = mImageManager.DownloadUpdateItems(itemsInfo, certificates, certificateChains, statuses);
+        EXPECT_EQ(err, ErrorEnum::eCanceled);
+    });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    EXPECT_TRUE(mImageManager.Cancel().IsNone());
+
+    downloadThread.join();
+
+    ExpectFileSize(GetBlobDownloadPath(), cDownloadedSize);
+}
+
+TEST_F(ImageManagerTest, DownloadUpdateItems_Cancel_ShrunkPartialDownload)
+{
+    constexpr size_t cBlobSize       = 1024;
+    constexpr size_t cPartialSize    = 600;
+    constexpr size_t cDownloadedSize = 50;
+
+    StaticArray<UpdateItemInfo, 5>               itemsInfo;
+    StaticArray<crypto::CertificateInfo, 1>      certificates;
+    StaticArray<crypto::CertificateChainInfo, 1> certificateChains;
+    StaticArray<UpdateItemStatus, 5>             statuses;
+
+    UpdateItemInfo item;
+    item.mItemID      = "service1";
+    item.mVersion     = "1.0.0";
+    item.mIndexDigest = cBlobDigest;
+    itemsInfo.PushBack(item);
+
+    CreateFile(GetBlobDownloadPath(), cPartialSize);
+
+    ExpectSingleBlobItem(cBlobSize, 2);
+
+    EXPECT_CALL(mDownloadingSpaceAllocatorMock, AllocateSpace(cBlobSize - cPartialSize))
+        .WillOnce(Invoke([this](size_t) { return MakeSpaceMock(1, 0); }));
+
+    EXPECT_CALL(mDownloadingSpaceAllocatorMock, FreeSpace(cBlobSize - cDownloadedSize)).Times(1);
+
+    EXPECT_CALL(mDownloaderMock, Download(_, _, _))
+        .WillOnce(Invoke([](const String&, const String&, const String& path) {
+            CreateFile(path, cDownloadedSize);
+
+            return ErrorEnum::eRuntime;
+        }));
+
+    EXPECT_CALL(mDownloaderMock, Cancel(_)).WillOnce(Return(ErrorEnum::eNone));
+
+    EXPECT_CALL(mStorageMock, UpdateItemState(_, _, _, _)).Times(AtLeast(0));
+
+    std::thread downloadThread([&]() {
+        auto err = mImageManager.DownloadUpdateItems(itemsInfo, certificates, certificateChains, statuses);
+        EXPECT_EQ(err, ErrorEnum::eCanceled);
+    });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    EXPECT_TRUE(mImageManager.Cancel().IsNone());
+
+    downloadThread.join();
+
+    ExpectFileSize(GetBlobDownloadPath(), cDownloadedSize);
+}
+
+TEST_F(ImageManagerTest, DownloadUpdateItems_Cancel_NoPartialFile_ReleasesSpace)
+{
+    constexpr size_t cBlobSize = 1024;
+
+    StaticArray<UpdateItemInfo, 5>               itemsInfo;
+    StaticArray<crypto::CertificateInfo, 1>      certificates;
+    StaticArray<crypto::CertificateChainInfo, 1> certificateChains;
+    StaticArray<UpdateItemStatus, 5>             statuses;
+
+    UpdateItemInfo item;
+    item.mItemID      = "service1";
+    item.mVersion     = "1.0.0";
+    item.mIndexDigest = cBlobDigest;
+    itemsInfo.PushBack(item);
+
+    ExpectSingleBlobItem(cBlobSize, 2);
+
+    EXPECT_CALL(mDownloadingSpaceAllocatorMock, AllocateSpace(cBlobSize)).WillOnce(Invoke([this](size_t) {
+        return MakeSpaceMock(0, 1);
+    }));
+
+    EXPECT_CALL(mDownloadingSpaceAllocatorMock, FreeSpace(_)).Times(0);
+
+    EXPECT_CALL(mDownloaderMock, Download(_, _, _)).WillOnce(Return(ErrorEnum::eRuntime));
+
+    EXPECT_CALL(mDownloaderMock, Cancel(_)).WillOnce(Return(ErrorEnum::eNone));
+
+    EXPECT_CALL(mStorageMock, UpdateItemState(_, _, _, _)).Times(AtLeast(0));
+
+    std::thread downloadThread([&]() {
+        auto err = mImageManager.DownloadUpdateItems(itemsInfo, certificates, certificateChains, statuses);
+        EXPECT_EQ(err, ErrorEnum::eCanceled);
+    });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    EXPECT_TRUE(mImageManager.Cancel().IsNone());
+
+    downloadThread.join();
+
+    ExpectFileRemoved(GetBlobDownloadPath());
+}
+
+TEST_F(ImageManagerTest, DownloadUpdateItems_DownloadFileInfoFailed_DiscardsDownload)
+{
+    constexpr size_t cBlobSize = 1024;
+
+    StaticArray<UpdateItemInfo, 5>               itemsInfo;
+    StaticArray<crypto::CertificateInfo, 1>      certificates;
+    StaticArray<crypto::CertificateChainInfo, 1> certificateChains;
+    StaticArray<UpdateItemStatus, 5>             statuses;
+
+    UpdateItemInfo item;
+    item.mItemID      = "service1";
+    item.mType        = UpdateItemTypeEnum::eService;
+    item.mVersion     = "1.0.0";
+    item.mIndexDigest = cBlobDigest;
+    itemsInfo.PushBack(item);
+
+    ExpectSingleBlobItem(cBlobSize, 3);
+
+    EXPECT_CALL(mDownloadingSpaceAllocatorMock, AllocateSpace(cBlobSize)).WillOnce(Invoke([this](size_t) {
+        return MakeSpaceMock(0, 1);
+    }));
+
+    EXPECT_CALL(mDownloadingSpaceAllocatorMock, FreeSpace(_)).Times(0);
+
+    EXPECT_CALL(mDownloaderMock, Download(_, _, _))
+        .WillOnce(Invoke([](const String&, const String&, const String& path) {
+            CreateFile(path, cBlobSize);
+
+            return ErrorEnum::eNone;
+        }));
+
+    EXPECT_CALL(mFileInfoProviderMock, GetFileInfo(_, _, _)).WillOnce(Return(ErrorEnum::eRuntime));
+
+    EXPECT_CALL(mStorageMock, UpdateItemState(_, _, ItemState(ItemStateEnum::eFailed), _))
+        .WillOnce(Return(ErrorEnum::eNone));
+
+    auto err = mImageManager.DownloadUpdateItems(itemsInfo, certificates, certificateChains, statuses);
+
+    EXPECT_TRUE(err.IsNone());
+    ASSERT_EQ(statuses.Size(), 1);
+    EXPECT_EQ(statuses[0].mState, ItemStateEnum::eFailed);
+
+    ExpectFileRemoved(GetBlobDownloadPath());
 }
 
 TEST_F(ImageManagerTest, DownloadUpdateItems_RemovesOldPendingVersion)


### PR DESCRIPTION
PrepareDownloadSpace freed the space taken by a partially downloaded blob and then allocated the full blob size, reserving the partial size twice and briefly offering space still occupied on disk to other allocators sharing the partition. Reserve only the bytes still to be written and, on cancel, return the reserved but not written part instead of reallocating the difference, which underflowed when the downloader restarted the file.

Keep the reservation in DownloadSpace, settle it in a single place so the download file is removed before its space is freed, and guard EnsureBlob against paths leaving the space neither accepted nor released. Drop AllocateSpaceForPartialDownloads: the allocator already accounts files present on disk.