### PR TITLE
cm: imagemanager: limit number of stored item versions

### DIFF
--- a/src/core/cm/imagemanager/imagemanager.cpp
+++ b/src/core/cm/imagemanager/imagemanager.cpp
@@ -34,7 +34,7 @@ Error ImageManager::Init(AllocatorItf& allocator, const Config& config, StorageI
     mFileInfoProvider          = &fileInfoProvider;
     mOCISpec                   = &ociSpec;
 
-    auto items = MakeUnique<StaticArray<ItemInfo, cMaxNumUpdateItems>>(mAllocator);
+    auto items = MakeUnique<StaticArray<ItemInfo, cMaxNumStoredItems>>(mAllocator);
     if (!items) {
         return AOS_ERROR_WRAP(ErrorEnum::eNoMemory);
     }
@@ -131,7 +131,7 @@ Error ImageManager::DownloadUpdateItems(const Array<UpdateItemInfo>& itemsInfo,
         statuses[i].mError   = ErrorEnum::eNone;
     }
 
-    auto storedItems = MakeUnique<StaticArray<ItemInfo, cMaxNumUpdateItems>>(mAllocator);
+    auto storedItems = MakeUnique<StaticArray<ItemInfo, cMaxNumStoredItems>>(mAllocator);
     if (!storedItems) {
         return AOS_ERROR_WRAP(ErrorEnum::eNoMemory);
     }
@@ -221,7 +221,7 @@ Error ImageManager::InstallUpdateItems(const Array<UpdateItemInfo>& itemsInfo, A
         statuses[i].mError   = ErrorEnum::eNone;
     }
 
-    auto storedItems = MakeUnique<StaticArray<ItemInfo, cMaxNumUpdateItems>>(mAllocator);
+    auto storedItems = MakeUnique<StaticArray<ItemInfo, cMaxNumStoredItems>>(mAllocator);
     if (!storedItems) {
         return AOS_ERROR_WRAP(ErrorEnum::eNoMemory);
     }
@@ -301,7 +301,7 @@ Error ImageManager::GetUpdateItemsStatuses(Array<UpdateItemStatus>& statuses)
 
     LOG_DBG() << "Get update items statuses";
 
-    auto items = MakeUnique<StaticArray<ItemInfo, cMaxNumUpdateItems>>(mAllocator);
+    auto items = MakeUnique<StaticArray<ItemInfo, cMaxNumStoredItems>>(mAllocator);
     if (!items) {
         return ErrorEnum::eNoMemory;
     }
@@ -459,7 +459,7 @@ RetWithError<size_t> ImageManager::RemoveItem(const String& id, const String& ve
 
     LOG_DBG() << "Remove item" << Log::Field("id", id) << Log::Field("version", version);
 
-    auto storedItems = MakeUnique<StaticArray<ItemInfo, cMaxNumUpdateItems>>(mAllocator);
+    auto storedItems = MakeUnique<StaticArray<ItemInfo, cMaxNumItemVersions>>(mAllocator);
     if (!storedItems) {
         return {0, AOS_ERROR_WRAP(ErrorEnum::eNoMemory)};
     }
@@ -509,7 +509,7 @@ Error ImageManager::RemoveOutdatedItems()
 
     LOG_DBG() << "Remove outdated items";
 
-    auto items = MakeUnique<StaticArray<ItemInfo, cMaxNumUpdateItems>>(mAllocator);
+    auto items = MakeUnique<StaticArray<ItemInfo, cMaxNumStoredItems>>(mAllocator);
     if (!items) {
         return AOS_ERROR_WRAP(ErrorEnum::eNoMemory);
     }
@@ -548,6 +548,71 @@ Error ImageManager::RemoveOutdatedItems()
         auto [totalSize, err] = CleanupOrphanedBlobs();
         if (!err.IsNone()) {
             return err;
+        }
+
+        LOG_DBG() << "Cleaned up orphaned blobs" << Log::Field("size", totalSize);
+
+        mInstallSpaceAllocator->FreeSpace(totalSize);
+    }
+
+    return ErrorEnum::eNone;
+}
+
+Error ImageManager::RemoveOldItemVersions(const String& itemID, Array<ItemInfo>& storedItems)
+{
+    size_t numVersions = 0;
+
+    for (const auto& item : storedItems) {
+        if (item.mItemID == itemID) {
+            numVersions++;
+        }
+    }
+
+    bool hasRemovedItems = false;
+
+    while (numVersions >= cMaxNumItemVersions) {
+        auto oldestIt = storedItems.end();
+
+        for (auto it = storedItems.begin(); it != storedItems.end(); ++it) {
+            if (it->mItemID != itemID || it->mState != ItemStateEnum::eRemoved) {
+                continue;
+            }
+
+            if (oldestIt == storedItems.end() || it->mTimestamp < oldestIt->mTimestamp) {
+                oldestIt = it;
+            }
+        }
+
+        if (oldestIt == storedItems.end()) {
+            break;
+        }
+
+        LOG_DBG() << "Remove old item version" << Log::Field("itemID", itemID)
+                  << Log::Field("version", oldestIt->mVersion);
+
+        if (auto err = mStorage->RemoveItem(itemID, oldestIt->mVersion); !err.IsNone()) {
+            return AOS_ERROR_WRAP(err);
+        }
+
+        if (auto err = mInstallSpaceAllocator->RestoreOutdatedItem(itemID, oldestIt->mVersion); !err.IsNone()) {
+            LOG_ERR() << "Failed to restore outdated item" << Log::Field("itemID", itemID)
+                      << Log::Field("version", oldestIt->mVersion) << Log::Field(err);
+        }
+
+        for (auto* listener : mListeners) {
+            listener->OnItemRemoved(itemID);
+        }
+
+        storedItems.Erase(oldestIt);
+
+        numVersions--;
+        hasRemovedItems = true;
+    }
+
+    if (hasRemovedItems) {
+        auto [totalSize, err] = CleanupOrphanedBlobs();
+        if (!err.IsNone()) {
+            return AOS_ERROR_WRAP(err);
         }
 
         LOG_DBG() << "Cleaned up orphaned blobs" << Log::Field("size", totalSize);
@@ -803,6 +868,11 @@ Error ImageManager::ProcessDownloadRequest(const Array<UpdateItemInfo>& itemsInf
         });
 
         if (sameVersionIt == storedItems.end()) {
+            if (auto err = RemoveOldItemVersions(itemInfo.mItemID, storedItems); !err.IsNone()) {
+                LOG_ERR() << "Failed to remove old item versions" << Log::Field("id", itemInfo.mItemID)
+                          << Log::Field(err);
+            }
+
             ItemInfo newItem;
             newItem.mItemID      = itemInfo.mItemID;
             newItem.mType        = itemInfo.mType;
@@ -1664,7 +1734,7 @@ RetWithError<size_t> ImageManager::CleanupOrphanedBlobs()
 
     size_t totalSize = 0;
 
-    auto storedItems = MakeUnique<StaticArray<ItemInfo, cMaxNumUpdateItems>>(mAllocator);
+    auto storedItems = MakeUnique<StaticArray<ItemInfo, cMaxNumStoredItems>>(mAllocator);
     if (!storedItems) {
         return {0, AOS_ERROR_WRAP(ErrorEnum::eNoMemory)};
     }

--- a/src/core/cm/imagemanager/imagemanager.hpp
+++ b/src/core/cm/imagemanager/imagemanager.hpp
@@ -172,11 +172,13 @@ private:
     static constexpr auto cBlobsDirName = "blobs";
 
     static constexpr auto cMaxNumListeners    = 1;
-    static constexpr auto cMaxNumItemVersions = 2;
     static constexpr auto cRetryTimeout       = Time::cSeconds * 2;
     static constexpr auto cDigestAlgorithmLen = 16;
+    static constexpr auto cMaxNumItemVersions = 2;
+    static constexpr auto cMaxNumStoredItems  = cMaxNumUpdateItems * cMaxNumItemVersions;
 
     Error RemoveOutdatedItems();
+    Error RemoveOldItemVersions(const String& itemID, Array<ItemInfo>& storedItems);
     Error WaitForStop();
     Error AllocateSpaceForPartialDownloads();
     Error RemovePendingItems(const Array<ItemInfo>& storedItems, Array<UpdateItemStatus>& statuses);

--- a/src/core/cm/imagemanager/tests/imagemanager.cpp
+++ b/src/core/cm/imagemanager/tests/imagemanager.cpp
@@ -962,6 +962,151 @@ TEST_F(ImageManagerTest, DownloadUpdateItems_RemovesOldFailedVersion)
     EXPECT_EQ(statuses[0].mState, ItemStateEnum::ePending);
 }
 
+TEST_F(ImageManagerTest, DownloadUpdateItems_RemovesExcessRemovedVersion)
+{
+    StaticArray<UpdateItemInfo, 5>               itemsInfo;
+    StaticArray<crypto::CertificateInfo, 1>      certificates;
+    StaticArray<crypto::CertificateChainInfo, 1> certificateChains;
+    StaticArray<UpdateItemStatus, 5>             statuses;
+
+    UpdateItemInfo item;
+    item.mItemID      = "service1";
+    item.mVersion     = "2.0.0";
+    item.mIndexDigest = "sha256:abc123";
+    itemsInfo.PushBack(item);
+
+    EXPECT_CALL(mStorageMock, GetAllItemsInfos(_)).WillRepeatedly(Invoke([](Array<ItemInfo>& items) {
+        ItemInfo removedItem;
+        removedItem.mItemID      = "service1";
+        removedItem.mVersion     = "1.0.0";
+        removedItem.mIndexDigest = "sha256:old100";
+        removedItem.mState       = ItemStateEnum::eRemoved;
+        removedItem.mTimestamp   = Time::Now().Add(-(Time::cSeconds * 5));
+        items.PushBack(removedItem);
+
+        ItemInfo installedItem;
+        installedItem.mItemID      = "service1";
+        installedItem.mVersion     = "1.1.0";
+        installedItem.mIndexDigest = "sha256:old110";
+        installedItem.mState       = ItemStateEnum::eInstalled;
+        installedItem.mTimestamp   = Time::Now();
+        items.PushBack(installedItem);
+
+        return ErrorEnum::eNone;
+    }));
+
+    size_t numRemoved = 0;
+
+    EXPECT_CALL(mStorageMock, RemoveItem(_, _))
+        .WillRepeatedly(Invoke([&numRemoved](const String& itemID, const String& version) {
+            EXPECT_EQ(itemID, "service1");
+            EXPECT_EQ(version, "1.0.0");
+
+            numRemoved++;
+
+            return ErrorEnum::eNone;
+        }));
+
+    EXPECT_CALL(mInstallSpaceAllocatorMock, RestoreOutdatedItem(_, _)).WillRepeatedly(Return(ErrorEnum::eNone));
+    EXPECT_CALL(mInstallSpaceAllocatorMock, FreeSpace(_)).Times(AtLeast(1));
+
+    EXPECT_CALL(mStorageMock, AddItem(_)).WillOnce(Invoke([](const ItemInfo& item) {
+        EXPECT_EQ(item.mItemID, "service1");
+        EXPECT_EQ(item.mVersion, "2.0.0");
+        EXPECT_EQ(item.mState, ItemStateEnum::eDownloading);
+
+        return ErrorEnum::eNone;
+    }));
+
+    EXPECT_CALL(mBlobInfoProviderMock, GetBlobsInfos(_, _))
+        .WillRepeatedly(Invoke([](const auto&, Array<BlobInfo>& blobsInfo) {
+            BlobInfo info;
+            info.mDigest = "sha256:000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+            info.mSize   = 1024;
+            info.mURLs.PushBack("http://test.com/blob");
+            info.mDecryptInfo.EmplaceValue();
+            info.mSignInfo.EmplaceValue();
+
+            for (size_t i = 0; i < crypto::cSHA256Size; i++) {
+                info.mSHA256.PushBack(static_cast<uint8_t>(i));
+            }
+
+            blobsInfo.PushBack(info);
+
+            return ErrorEnum::eNone;
+        }));
+
+    EXPECT_CALL(mDownloadingSpaceAllocatorMock, FreeSpace(_)).Times(AtLeast(0));
+    EXPECT_CALL(mDownloadingSpaceAllocatorMock, AllocateSpace(_))
+        .WillRepeatedly(Invoke([this](size_t) -> RetWithError<UniquePtr<spaceallocator::SpaceItf>> {
+            auto space = MakeUnique<spaceallocator::SpaceMock>(&mAllocator);
+            EXPECT_TRUE(space);
+
+            EXPECT_CALL(*space, Accept()).Times(AtLeast(0));
+            EXPECT_CALL(*space, Release()).Times(AtLeast(0));
+
+            return {std::move(space), ErrorEnum::eNone};
+        }));
+
+    EXPECT_CALL(mInstallSpaceAllocatorMock, AllocateSpace(_))
+        .WillRepeatedly(Invoke([this](size_t) -> RetWithError<UniquePtr<spaceallocator::SpaceItf>> {
+            auto space = MakeUnique<spaceallocator::SpaceMock>(&mAllocator);
+            EXPECT_TRUE(space);
+
+            EXPECT_CALL(*space, Accept()).Times(AtLeast(0));
+            EXPECT_CALL(*space, Release()).Times(AtLeast(0));
+
+            return {std::move(space), ErrorEnum::eNone};
+        }));
+
+    EXPECT_CALL(mDownloaderMock, Download(_, _, _)).WillRepeatedly(Return(ErrorEnum::eNone));
+
+    EXPECT_CALL(mOCISpecMock, LoadImageIndex(_, _)).WillRepeatedly(Invoke([](const String&, oci::ImageIndex& index) {
+        oci::IndexContentDescriptor manifest;
+        manifest.mDigest = "sha256:fedcba0987654321fedcba0987654321fedcba0987654321fedcba0987654321";
+        index.mManifests.PushBack(manifest);
+
+        return ErrorEnum::eNone;
+    }));
+
+    EXPECT_CALL(mOCISpecMock, LoadImageManifest(_, _))
+        .WillRepeatedly(Invoke([](const String&, oci::ImageManifest& manifest) {
+            manifest.mConfig.mDigest = "sha256:config1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
+
+            oci::ContentDescriptor layer;
+            layer.mDigest = "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+            manifest.mLayers.PushBack(layer);
+
+            return ErrorEnum::eNone;
+        }));
+
+    EXPECT_CALL(mCryptoHelperMock, Decrypt(_, _, _)).WillRepeatedly(Return(ErrorEnum::eNone));
+    EXPECT_CALL(mCryptoHelperMock, ValidateSigns(_, _, _, _)).WillRepeatedly(Return(ErrorEnum::eNone));
+
+    EXPECT_CALL(mFileInfoProviderMock, GetFileInfo(_, _, _))
+        .WillRepeatedly(Invoke([](const String&, fs::FileInfo& info, crypto::Hash) {
+            for (size_t i = 0; i < crypto::cSHA256Size; i++) {
+                info.mCheckSum.PushBack(static_cast<uint8_t>(i));
+            }
+
+            info.mSize = 1024;
+
+            return ErrorEnum::eNone;
+        }));
+
+    EXPECT_CALL(mStorageMock, UpdateItemState(_, _, ItemState(ItemStateEnum::ePending), _))
+        .WillOnce(Return(ErrorEnum::eNone));
+
+    auto err = mImageManager.DownloadUpdateItems(itemsInfo, certificates, certificateChains, statuses);
+
+    EXPECT_TRUE(err.IsNone());
+    EXPECT_GE(numRemoved, 1);
+    ASSERT_EQ(statuses.Size(), 1);
+    EXPECT_EQ(statuses[0].mItemID, "service1");
+    EXPECT_EQ(statuses[0].mVersion, "2.0.0");
+    EXPECT_EQ(statuses[0].mState, ItemStateEnum::ePending);
+}
+
 TEST_F(ImageManagerTest, InstallUpdateItems_Success)
 {
     StaticArray<UpdateItemInfo, 5>   itemsInfo;


### PR DESCRIPTION
CM kept every removed item version in storage until updateItemTTL expired (30d by default), while all read buffers were sized against cMaxNumItemVersions (2). On the third consecutive update of the same item GetItemInfos() overflowed its array and the launcher failed with "can't add item info", leaving the instance unable to start.

Trim the oldest removed versions before adding a new one, the way SM does it in RemoveOldItemVersions(), so an item never exceeds cMaxNumItemVersions rows. An installed version is never force removed: if no removed version is left to reclaim, the trim just stops.

Move cMaxNumItemVersions to the storage interface as it now describes a storage invariant, and add cMaxNumStoredItems for the whole table. GetAllItemsInfos() buffers counted items instead of rows and would have overflowed the same way past 64 rows, so size them accordingly.